### PR TITLE
Compile with Clang

### DIFF
--- a/src/cross.c
+++ b/src/cross.c
@@ -77,6 +77,7 @@ Lit_croisement * (), lit_croisement2 ()
 **************************************************************************/
 #define			CODES_SIGNES
 #include		"cross.h"
+#include    <string.h>
 char			option_affichage;
 /*****************************************************************************
 * FONCTIONS DIVERSES DE GESTION DES CHAINES DE CROISEMENTS POUR LIENS

--- a/src/polynomesAZ.c
+++ b/src/polynomesAZ.c
@@ -149,7 +149,7 @@ polySimplifie(p1,n1)
 	return i2;
 }
 
-polyTrie(p1,n1)
+void polyTrie(p1,n1)
 	MONOME		p1[];
 	int			n1;
 {

--- a/src/polynomesAZ.h
+++ b/src/polynomesAZ.h
@@ -17,4 +17,13 @@ typedef struct{
 	float	coeff;
 	int		degA, degZ;
 }MONOME;
+
+int polyCopie(MONOME p1[],MONOME p2[], int n2);
+int polyProduit(MONOME p1[], int n1,MONOME p2[], int n2,MONOME p3[], int n3);
+int polySomme(MONOME p1[], int n1,MONOME p2[], int n2,MONOME p3[], int n3);
+int polySimplifie(MONOME p1[], int n1);
+void polyAffiche(MONOME p1[], int n1, FILE *pout);
+void polyLatex(MONOME p1[], int n1);
+void polyMapple(MONOME p1[], int n1);
+
 #endif


### PR DESCRIPTION
Implicit function declaration was deprecated as of C99, but most compilers left this as a warning until Xcode 12 changed to an error.

https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes

Was unable to find a compiler option that would cause clang to treat issue as a warning. This change explicitly declares functions from src/polynomesAZ.c in src/polynomesAZ.h and includes string.h in src/cross.c.