### PR TITLE
Include vector

### DIFF
--- a/src/clkConformationBfacf3.h
+++ b/src/clkConformationBfacf3.h
@@ -10,6 +10,7 @@
 
 #include <list>
 #include <map>
+#include <vector>
 
 #include "clk.h"
 #include "clkConformationAsList.h"


### PR DESCRIPTION
This is a small change. It seems that src/clkConformationBfacf3.h had used std::vector, but never included vector. The project had thus built for clang, but not for g++.