### PR TITLE
Run tests with make test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,5 +27,5 @@ sampleTests_CXXFLAGS = $(AM_CXXFLAGS) -Isrc
 ACLOCAL_AMFLAGS = -I m4 --install
 EXTRA_DIST = m4/NOTES
 
-test: 
+test: all 
 	./testRecombo

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,4 +28,4 @@ ACLOCAL_AMFLAGS = -I m4 --install
 EXTRA_DIST = m4/NOTES
 
 test: 
-	@echo "Would it not be nice if we knew that this worked?"
+	./testRecombo


### PR DESCRIPTION
Previously the `test` target for the make file had been only a stub. Now it runs `testRecombo`.