### PR TITLE
Remove circular dependency of test in all from make file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,5 +27,5 @@ sampleTests_CXXFLAGS = $(AM_CXXFLAGS) -Isrc
 ACLOCAL_AMFLAGS = -I m4 --install
 EXTRA_DIST = m4/NOTES
 
-test: all 
+test: testRecombo 
 	./testRecombo

--- a/Makefile.in
+++ b/Makefile.in
@@ -2119,8 +2119,8 @@ uninstall-am: uninstall-binPROGRAMS
 
 all: mmc zAnalyzer idknot homfly xinger testRecombo sampleTests test 
 
-test: 
-	@echo "Would it not be nice if we knew that this worked?"
+test: testRecombo 
+	./testRecombo
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
Previously the `test` target of make file had depended on `all`, and all had depended on 'test'. That was a circular dependency.

To test that this works, type
   ./configure
   make clean
   make test

The result should be that `testRecombo` will build and run (and all fifteen tests should pass). 
