### PR TITLE
Reuben/test parallel

### DIFF
--- a/src/tests/recomboCriteriaTests.cpp
+++ b/src/tests/recomboCriteriaTests.cpp
@@ -16,6 +16,7 @@
 #include <pseudorandom.h>
 
 #include <sstream>
+#include <iostream>
 
 #include <algorithm>
 #include <deque>
@@ -39,42 +40,31 @@ class recomboCriteriaTestClass
     mmchain mmctest;
     recomboCriteriaTestClass(); 
     bool testParallelRecombination();
-    
-    
-    
-
 };
+
 const int recomboCriteriaTestClass::preRecomboUnknot[120]={0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0, 5, 0, 0, 6, 0, 1, 6, 0, 2, 6, 0, 3, 6, 0, 4, 6, 0, 4, 5, 0, 5, 5, 0, 6, 5, 0, 7, 5, 0, 7, 4, 0, 7, 3, 0, 7, 2, 0, 7, 1, 0, 7, 0, 0, 7, -1, 0, 6, -1, 0, 5, -1, 0, 4, -1, 0, 3, -1, 0, 3, 0, 0, 3, 0, 1, 3, 1, 1, 3, 2, 1, 3, 2, 0, 3, 3, 0, 3, 4, 0, 4, 4, 0, 5, 4, 0, 5, 3, 0, 5, 2, 0, 5, 1, 0, 4, 1, 0, 3, 1, 0, 2, 1, 0, 1, 1, 0};
 const int recomboCriteriaTestClass::postRecomboUnknot[120]={0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0, 5, 0, 0, 6, 0, 1, 6, 0, 2, 6, 0, 3, 6, 0, 4, 6, 0, 4, 5, 0, 4, 4, 0, 3, 4, 0, 3, 3, 0, 3, 2, 0, 3, 2, 1, 3, 1, 1, 3, 0, 1, 3, 0, 0, 3, -1, 0, 4, -1, 0, 5, -1, 0, 6, -1, 0, 7, -1, 0, 7, 0, 0, 7, 1, 0, 7, 2, 0, 7, 3, 0, 7, 4, 0, 7, 5, 0, 6, 5, 0, 5, 5, 0, 5, 4, 0, 5, 3, 0, 5, 2, 0, 5, 1, 0, 4, 1, 0, 3, 1, 0, 2, 1, 0, 1, 1};
 const clkConformationAsList recomboCriteriaTestClass::preConformationList(preRecomboUnknot,40);
 const clkConformationAsList recomboCriteriaTestClass::postConformationList(postRecomboUnknot,40);
 
 recomboCriteriaTestClass::recomboCriteriaTestClass() : preConformation(preConformationList), postConformation(postConformationList)
-{
-
-
-
-}
+{}
 
 bool testParallelRecombination()
 {
     recomboCriteriaTestClass rctc;
-    //The choice between either as the before recombination is arbitrary; 
-    //they recombine into eachother without outside influence
 
     int sites = 0;
     int sitechoice = 0;
-    //result.getVertex(0,v);
-    //v*=-1;
-    //result.translate(v);
-    //clkConformationBfacf3 postConformation(reclass.postConformationList);
-    char orientation = 'p';
-    // TODO: RB had to comment out next line to build tests
-    // sites=rctc.preConformation.countRecomboSites(18,22,orientation);
-    rctc.preConformation.performRecombination(sitechoice);
+    int min_arc = 18, max_arc = 22;
+    int sequence_type = 1;
+    int recombo_type = 1;
+    int n_components = 1;
+    int total_para_site, total_anti_site, Para_site, Anti_site;
+    sites=rctc.preConformation.countRecomboSites(min_arc, max_arc, sequence_type, recombo_type, total_para_site, total_anti_site, Para_site, Anti_site);
+    rctc.preConformation.performRecombination(cout, sequence_type, recombo_type, n_components, sitechoice);
     ASSERT_EQUAL(rctc.preConformation.size(),1);
     ASSERT(rctc.preConformation.getComponent(0)==rctc.postConformation.getComponent(0));
-    //clkConformationAsList result(rctc.preConformation.getComponent(0));
     
     return true;
 }

--- a/src/tests/recomboCriteriaTests.cpp
+++ b/src/tests/recomboCriteriaTests.cpp
@@ -54,6 +54,8 @@ bool testParallelRecombination()
 {
     recomboCriteriaTestClass rctc;
 
+    ostringstream out;
+
     int sites = 0;
     int sitechoice = 0;
     int min_arc = 18, max_arc = 22;
@@ -62,7 +64,7 @@ bool testParallelRecombination()
     int n_components = 1;
     int total_para_site, total_anti_site, Para_site, Anti_site;
     sites=rctc.preConformation.countRecomboSites(min_arc, max_arc, sequence_type, recombo_type, total_para_site, total_anti_site, Para_site, Anti_site);
-    rctc.preConformation.performRecombination(cout, sequence_type, recombo_type, n_components, sitechoice);
+    rctc.preConformation.performRecombination(sitechoice);
     ASSERT_EQUAL(rctc.preConformation.size(),1);
     ASSERT(rctc.preConformation.getComponent(0)==rctc.postConformation.getComponent(0));
     

--- a/src/tests/unitTestMain.cpp
+++ b/src/tests/unitTestMain.cpp
@@ -37,7 +37,7 @@ int main(void)
 	suite.add_test(testRandomInteger, "pseudorandom integers");
 	suite.add_test(testPrecomputedBfacf3Probs, "Precomputed BFACF probabilities");
 	// TODO: RB had to comment next line because of Segmentation fault 11
-	// suite.add_test(testParallelRecombination, "Recombination between unknots");
+	suite.add_test(testParallelRecombination, "Recombination between unknots");
 
 	suite.run_suite();
 }


### PR DESCRIPTION
Previously, we were not running testParallelRecombination. The function clkConformationBfacf3::countRecomboSites had changed its signature, but testParallelRecombination was not correctly rewritten.

Addresses #8 