### PR TITLE
fix:precompute q and associated tests

### DIFF
--- a/src/clkConformationBfacf3.cpp
+++ b/src/clkConformationBfacf3.cpp
@@ -790,11 +790,11 @@ void clkConformationBfacf3::step(int n)
       perform_move(implementation->clkp);
 }
 
-void clkConformationBfacf3::init_Q(double z, double q) //these probabilities are suspect
+void clkConformationBfacf3::init_Q(double z, double q)
 {
 	for (int i=4; i < MAX_PRECOMPUTE_LENGTH; i++){
 		probMap[i].p_plus2 = (pow((i+2),(q-1))*(z * z)) / (pow(i,(q-1)) + 3.0*pow((i+2),q-1) * z * z);
-		probMap[i].p_minus2 = pow(i,(q-1)) / (pow(i,(q-1)) + 3.0*pow((i+2),q-1) * z * z);
+		probMap[i].p_minus2 = pow(i-2, (q - 1)) / (pow(i-2, (q - 1)) + 3.0*pow(i, q - 1) * z * z);
 		probMap[i].p_0 = .5*(probMap[i].p_plus2 + probMap[i].p_minus2);
 	}
 }
@@ -843,7 +843,6 @@ void clkConformationBfacf3::stepQ(long int c, int q, double z)
 {
 	for (long int i = 0; i < c; i++)
 		stepQ(q, z);
-		//perform_move_q(implementation->clkp); //see above
 }
 
 

--- a/src/clkConformationBfacf3.cpp
+++ b/src/clkConformationBfacf3.cpp
@@ -815,13 +815,6 @@ void clkConformationBfacf3::stepQ(int current_q, double z)
 	for (int i=0; i < n_comps; i++){
 		n += getComponent(i).size();
 	}
-	/*
-	//direct computation
-	double p_plus2 = (pow((n+2),(q-1))*(z * z)) / (pow(n,(q-1)) + 3.0*pow((n+2),q-1) * z * z);
-	double p_minus2 = pow(n,(q-1)) / (pow(n,(q-1)) + 3.0*pow((n+2),q-1) * z * z);
-	double p_0 = .5*(p_plus2 + p_minus2);
-	bfacf_set_probabilities(comp, p_minus2, p_0, p_plus2);*/
-
 	if (getZ() != z || current_q != q){
 		q = current_q;
 		setZ(z);

--- a/src/tests/clkTests.cpp
+++ b/src/tests/clkTests.cpp
@@ -711,23 +711,21 @@ bool testPrecomputedBfacf3Probs(){
 	//compare precomputed probabilities with directly computed probabilities
 	for (int n = 4; n < MAX_PRECOMPUTE_LENGTH; n++){
 		ASSERT(knot.probMap[n].p_plus2 == (pow((n + 2), (q - 1))*(z * z)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z));
-		ASSERT(knot.probMap[n].p_minus2 == pow(n, (q - 1)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z));
-		ASSERT(knot.probMap[n].p_0 == .5*((pow((n + 2), (q - 1))*(z * z)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z) +
-			pow(n, (q - 1)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z)));
+		ASSERT(knot.probMap[n].p_minus2 == pow(n-2, (q - 1)) / (pow(n-2, (q - 1)) + 3.0*pow(n, q - 1) * z * z));
+		ASSERT(knot.probMap[n].p_0 == .5 * (knot.probMap[n].p_plus2 + knot.probMap[n].p_minus2));
 	}
 	//select a different z with q=3
 	z = .1812; q = 3;
 	//precompute
 	knot.init_Q(z, q);
 	//compare
-	for (int n = 4; n < MAX_PRECOMPUTE_LENGTH; n++){
-		ASSERT(knot.probMap[n].p_plus2 == (pow((n + 2), (q - 1))*(z * z)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z));
-		ASSERT(knot.probMap[n].p_minus2 == pow(n, (q - 1)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z));
-		ASSERT(knot.probMap[n].p_0 == .5*((pow((n + 2), (q - 1))*(z * z)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z) +
-			pow(n, (q - 1)) / (pow(n, (q - 1)) + 3.0*pow((n + 2), q - 1) * z * z)));
-	}
-	
-	return true;
+	for (int n = 4; n < MAX_PRECOMPUTE_LENGTH; n++) {
+        ASSERT(knot.probMap[n].p_plus2 ==
+               (pow((n + 2), (q - 1)) * (z * z)) / (pow(n, (q - 1)) + 3.0 * pow((n + 2), q - 1) * z * z));
+        ASSERT(knot.probMap[n].p_minus2 == pow(n - 2, (q - 1)) / (pow(n - 2, (q - 1)) + 3.0 * pow(n, q - 1) * z * z));
+        ASSERT(knot.probMap[n].p_0 == .5 * (knot.probMap[n].p_plus2 + knot.probMap[n].p_minus2));
+    }
+    return true;
 }
 
 bool testBfacf3ProbsHandComputed() {


### PR DESCRIPTION
Fixed the formula used to pre-compute BFACF probabilities for P(-2) q > 1 and associated tests. 