### PR TITLE
Introduce gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.16)
 project(recombo)
 include_directories(src)
 set(CMAKE_CXX_STANDARD 11)
+
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+)
+FetchContent_MakeAvailable(googletest)
 set(EXECUTABLE_OUTPUT_PATH src/bin)
 set(TEST_SOURCE_FILES
         src/tests/argprocessorTests.cpp
@@ -72,6 +80,7 @@ set(XINGER_SOURCE_FILES
 add_executable(xinger ${XINGER_SOURCE_FILES} src/xinger/main.cpp)
 add_executable(zAnalyzer ${SHARED_SOURCE_FILES} src/zAnalyzerMain.cpp)
 add_executable(unitTest ${SHARED_SOURCE_FILES} ${TEST_SOURCE_FILES} src/tests/unitTestMain.cpp)
+target_link_libraries(unitTest gtest gtest_main)
 add_executable(mmc ${SHARED_SOURCE_FILES} src/mmcMain.cpp)
 add_executable(homfly ${SHARED_SOURCE_FILES} src/homfly1_21.c src/cross.c src/cross.h)
 # Legacy K&R C files need relaxed compiler settings

--- a/src/tests/unitTestMain.cpp
+++ b/src/tests/unitTestMain.cpp
@@ -1,4 +1,4 @@
-#include "testFramework.h"
+#include <gtest/gtest.h>
 
 #include "argprocessorTests.h"
 #include "autocorrTests.h"
@@ -6,40 +6,24 @@
 #include "randomTests.h"
 #include "recomboCriteriaTests.h"
 
-using namespace std;
+TEST(AutocorrTest, Autocorr) { EXPECT_TRUE(testAutocorr()); }
 
-int main(void)
-{
-	test_suite suite;
+TEST(ClkTest, Data) { EXPECT_TRUE(testData()); }
+TEST(ClkTest, CopyScalarToVector) { EXPECT_TRUE(testCopyScalarToVector()); }
+TEST(ClkTest, GenericOutput) { EXPECT_TRUE(testGenericOutput()); }
+TEST(ClkTest, Rog) { EXPECT_TRUE(testRog()); }
+TEST(ClkTest, WrAcn) { EXPECT_TRUE(testWrAcn()); }
+TEST(ClkTest, ReadFromText) { EXPECT_TRUE(testReadFromText()); }
+TEST(ClkTest, ReadFromCoords) { EXPECT_TRUE(testReadFromCoords()); }
+TEST(ClkTest, RandomReset) { EXPECT_TRUE(testRandomReset()); }
+TEST(ClkTest, Bfacf3) { EXPECT_TRUE(testBfacf3()); }
+TEST(ClkTest, Bfacf3SetZ) { EXPECT_TRUE(testBfacf3SetZ()); }
+TEST(ClkTest, Bfacf3Run) { EXPECT_TRUE(testBfacf3Run()); }
 
-	suite.add_test(testAutocorr, "autocorr");
+TEST(RandomTest, RawSequence) { EXPECT_TRUE(testRandom()); }
+TEST(RandomTest, Integers) { EXPECT_TRUE(testRandomInteger()); }
 
-	suite.add_test(testData, "data");
-	suite.add_test(testCopyScalarToVector, "testCopyScalarToVector");
+TEST(BfacfProbsTest, Precomputed) { EXPECT_TRUE(testPrecomputedBfacf3Probs()); }
+TEST(BfacfProbsTest, HandComputed) { EXPECT_TRUE(testBfacf3ProbsHandComputed()); }
 
-	suite.add_test(testGenericOutput, "testGenericOutput");
-
-	suite.add_test(testRog, "testRog");
-
-	suite.add_test(testWrAcn, "testWrAcn");
-
-	suite.add_test(testReadFromText, "testReadFromText");
-	suite.add_test(testReadFromCoords, "testReadFromCoords");
-
-	suite.add_test(testRandomReset, "testRandomReset");
-	suite.add_test(testBfacf3, "testBfacf3");
-	suite.add_test(testBfacf3SetZ, "testBfacf3SetZ");
-	suite.add_test(testBfacf3Run, "testBfacf3Run");
-	//suite.add_test(testBfacf3CountEdges, "testBfacf3CountEdges"); //incomplete 
-
-	suite.add_test(testRandom, "raw sequence for pseudorandom number generator", "", 
-		"Random number generator fails to produce expected sequence.");
-	suite.add_test(testRandomInteger, "pseudorandom integers");
-	suite.add_test(testPrecomputedBfacf3Probs, "Precomputed BFACF probabilities");
-	suite.add_test(testBfacf3ProbsHandComputed, "Compare computed BFACF probabilities vs hand computed");
-	// TODO: RB had to comment next line because of Segmentation fault 11
-	suite.add_test(testParallelRecombination, "Recombination between unknots");
-
-	suite.run_suite();
-}
-
+TEST(RecomboTest, ParallelRecombination) { EXPECT_TRUE(testParallelRecombination()); }


### PR DESCRIPTION
Migrate unitTest target to Google Test with minimal changes. GTest v1.14.0 is 
  fetched via FetchContent in CMake. The existing test functions (bool-returning
   with custom ASSERT macros) are unchanged — unitTestMain.cpp now wraps each   
  one in a TEST() macro via EXPECT_TRUE(). The old test framework remains as a
  compatibility shim; individual tests can be rewritten to use native gtest     
  assertions in follow-up work.