### PR TITLE
Test BFACF steps using newsud representations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(recombo_core STATIC
         src/legacy.cpp
         src/legacyBfacf.cpp
         src/mmchain.cpp
+        src/newsud.cpp
         src/polynomesAZ.c
         src/pseudorandom.cpp
         src/regularNgon.cpp

--- a/src/clkConformationAsList.cpp
+++ b/src/clkConformationAsList.cpp
@@ -18,6 +18,13 @@ using namespace std;
 
 clkConformationAsList::clkConformationAsList() { }
 
+clkConformationAsList::clkConformationAsList(const string& newsud, int x0, int y0, int z0)
+{
+   vector<threevector<int> > vertices = newsudToVertices(newsud, x0, y0, z0);
+   for (size_t i = 0; i < vertices.size(); i++)
+      data.push_back(vertices[i]);
+}
+
 clkConformationAsList::clkConformationAsList(const clk& orig)
 {
    threevector<int> v;

--- a/src/clkConformationAsList.cpp
+++ b/src/clkConformationAsList.cpp
@@ -158,6 +158,57 @@ bool clkConformationAsList::readFromText(const string& text)
    return readFromText(str);
 }
 
+string clkConformationAsList::writeAsNewsud() const
+{
+   string result;
+   int n = size();
+   if (n < 2) return result;
+
+   threevector<int> prev, curr, first;
+   getVertex(0, first);
+   prev = first;
+   for (int i = 1; i <= n; i++)
+   {
+      if (i < n)
+         getVertex(i, curr);
+      else
+         curr = first;
+      int dx = curr.getX() - prev.getX();
+      int dy = curr.getY() - prev.getY();
+      int dz = curr.getZ() - prev.getZ();
+      if (dx == 1) result += 'e';
+      else if (dx == -1) result += 'w';
+      else if (dy == 1) result += 'n';
+      else if (dy == -1) result += 's';
+      else if (dz == 1) result += 'u';
+      else if (dz == -1) result += 'd';
+      prev = curr;
+   }
+   return result;
+}
+
+bool clkConformationAsList::readFromNewsud(const string& s, int x0, int y0, int z0)
+{
+   clear();
+   int x = x0, y = y0, z = z0;
+   addVertexBack(x, y, z);
+   for (size_t i = 0; i + 1 < s.length(); i++)
+   {
+      switch (s[i])
+      {
+         case 'n': y++; break;
+         case 's': y--; break;
+         case 'e': x++; break;
+         case 'w': x--; break;
+         case 'u': z++; break;
+         case 'd': z--; break;
+         default: return false;
+      }
+      addVertexBack(x, y, z);
+   }
+   return true;
+}
+
 bool clkConformationAsList::lineIsVertex(std::string line)
 {
    int count = 0;

--- a/src/clkConformationAsList.cpp
+++ b/src/clkConformationAsList.cpp
@@ -8,6 +8,7 @@
 #include "clkConformationAsList.h"
 
 #include "genericConformation.h"
+#include "newsud.h"
 
 #include <iostream>
 #include <sstream>
@@ -189,23 +190,12 @@ string clkConformationAsList::writeAsNewsud() const
 
 bool clkConformationAsList::readFromNewsud(const string& s, int x0, int y0, int z0)
 {
+   vector<threevector<int> > vertices = newsudToVertices(s, x0, y0, z0);
+   if (vertices.empty() && !s.empty())
+      return false;
    clear();
-   int x = x0, y = y0, z = z0;
-   addVertexBack(x, y, z);
-   for (size_t i = 0; i + 1 < s.length(); i++)
-   {
-      switch (s[i])
-      {
-         case 'n': y++; break;
-         case 's': y--; break;
-         case 'e': x++; break;
-         case 'w': x--; break;
-         case 'u': z++; break;
-         case 'd': z--; break;
-         default: return false;
-      }
-      addVertexBack(x, y, z);
-   }
+   for (size_t i = 0; i < vertices.size(); i++)
+      addVertexBack(vertices[i]);
    return true;
 }
 

--- a/src/clkConformationAsList.h
+++ b/src/clkConformationAsList.h
@@ -108,9 +108,10 @@ public:
     */
    virtual std::string writeAsText() const;
 
+   virtual std::string writeAsNewsud() const;
+
    // TODO:
    //  virtual void writeAsUofS(std::ostream& os) const;
-   //  virtual void writeAsNewsud(std::ostream& os) const;
 
    // TODO: should throw exception for io error
    /**
@@ -150,9 +151,10 @@ public:
     */
    virtual bool readFromText(const std::string& text);
 
+   virtual bool readFromNewsud(const std::string& s, int x0 = 0, int y0 = 0, int z0 = 0);
+
    // TODO:
    //  virtual bool readFromUofS(std::istream& is);
-   //  virtual bool readFromNewsud(std::istream& is);
 
    /**
     * Inputs conformation in Rob Scharein's cube format. This formation is a

--- a/src/clkConformationAsList.h
+++ b/src/clkConformationAsList.h
@@ -36,6 +36,15 @@ public:
    clkConformationAsList(const int* coords, int numVerts);
 
    /**
+    * Constructor that reads vertices from a newsud direction string.
+    * @param newsud a string of direction characters (n, e, w, s, u, d).
+    * @param x0 starting x-coordinate (default 0).
+    * @param y0 starting y-coordinate (default 0).
+    * @param z0 starting z-coordinate (default 0).
+    */
+   clkConformationAsList(const std::string& newsud, int x0 = 0, int y0 = 0, int z0 = 0);
+
+   /**
     * Copy constructor.
     * @param orig new conformation will have same coordinates as orig.
     */

--- a/src/clkConformationBfacf3.cpp
+++ b/src/clkConformationBfacf3.cpp
@@ -779,6 +779,12 @@ void clkConformationBfacf3::setSeed(int seed)
    sRandSimple(seed);
 }
 
+string clkConformationBfacf3::writeAsNewsud(int component)
+{
+   clkConformationAsList asList(getComponent(component));
+   return asList.writeAsNewsud();
+}
+
 void clkConformationBfacf3::step()
 {
    perform_move(implementation->clkp);

--- a/src/clkConformationBfacf3.h
+++ b/src/clkConformationBfacf3.h
@@ -10,6 +10,7 @@
 
 #include <list>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "clk.h"
@@ -114,6 +115,13 @@ public:
     */
    void setSeed(int seed);
    
+   /**
+    * Returns the newsud direction string for a component.
+    * @param component index of component (default 0).
+    * @return newsud direction string.
+    */
+   std::string writeAsNewsud(int component = 0);
+
    /**
     * Attempt to perform a BFACF step on current conformation.
     */

--- a/src/newsud.cpp
+++ b/src/newsud.cpp
@@ -1,0 +1,84 @@
+#include "newsud.h"
+
+#include <set>
+
+bool newsudStep(char c, int& dx, int& dy, int& dz)
+{
+   dx = dy = dz = 0;
+   switch (c)
+   {
+      case 'e': dx =  1; return true;
+      case 'w': dx = -1; return true;
+      case 'n': dy =  1; return true;
+      case 's': dy = -1; return true;
+      case 'u': dz =  1; return true;
+      case 'd': dz = -1; return true;
+      default: return false;
+   }
+}
+
+std::vector<threevector<int> > newsudToVertices(const std::string& s, int x0, int y0, int z0)
+{
+   std::vector<threevector<int> > vertices;
+   int x = x0, y = y0, z = z0;
+   vertices.push_back(threevector<int>(x, y, z));
+   int dx, dy, dz;
+   for (size_t i = 0; i + 1 < s.size(); i++)
+   {
+      if (!newsudStep(s[i], dx, dy, dz))
+         return std::vector<threevector<int> >();
+      x += dx;
+      y += dy;
+      z += dz;
+      vertices.push_back(threevector<int>(x, y, z));
+   }
+   return vertices;
+}
+
+bool newsudIsClosed(const std::string& s)
+{
+   int x = 0, y = 0, z = 0;
+   int dx, dy, dz;
+   for (size_t i = 0; i < s.size(); i++)
+   {
+      if (!newsudStep(s[i], dx, dy, dz))
+         return false;
+      x += dx;
+      y += dy;
+      z += dz;
+   }
+   return x == 0 && y == 0 && z == 0;
+}
+
+struct ivec3
+{
+   int x, y, z;
+   bool operator<(const ivec3& o) const
+   {
+      if (x != o.x) return x < o.x;
+      if (y != o.y) return y < o.y;
+      return z < o.z;
+   }
+};
+
+bool newsudIsSelfAvoiding(const std::string& s)
+{
+   std::set<ivec3> visited;
+   ivec3 pos = {0, 0, 0};
+   visited.insert(pos);
+   int dx, dy, dz;
+   for (size_t i = 0; i < s.size(); i++)
+   {
+      if (!newsudStep(s[i], dx, dy, dz))
+         return false;
+      pos.x += dx;
+      pos.y += dy;
+      pos.z += dz;
+      if (i + 1 < s.size())
+      {
+         if (!visited.insert(pos).second)
+            return false;
+      }
+   }
+   return true;
+}

--- a/src/newsud.h
+++ b/src/newsud.h
@@ -1,0 +1,15 @@
+#ifndef NEWSUD_H
+#define NEWSUD_H
+
+#include <string>
+#include <vector>
+
+#include "threevector.h"
+
+bool newsudStep(char c, int& dx, int& dy, int& dz);
+std::vector<threevector<int> > newsudToVertices(const std::string& s, int x0 = 0, int y0 = 0, int z0 = 0);
+
+bool newsudIsClosed(const std::string& s);
+bool newsudIsSelfAvoiding(const std::string& s);
+
+#endif /* NEWSUD_H */

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(regressionTest
-        bfacf_regression_test.cpp)
+        bfacf_regression_test.cpp
+        bfacf_step_test.cpp)
 target_link_libraries(regressionTest recombo_core gtest gtest_main)
 add_test(NAME regressionTest COMMAND $<TARGET_FILE:regressionTest>)

--- a/test/regression/bfacf_step_test.cpp
+++ b/test/regression/bfacf_step_test.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "clkConformationAsList.h"
+#include "clkConformationBfacf3.h"
+
+using namespace std;
+
+class BfacfStepTest : public ::testing::Test
+{
+protected:
+   void TearDown() override
+   {
+      delete knot;
+   }
+
+   void init(const string& newsud, int seed)
+   {
+      clkConformationAsList conf(newsud);
+      knot = new clkConformationBfacf3(conf);
+      knot->setSeed(seed);
+   }
+
+   clkConformationBfacf3* knot = NULL;
+};
+
+TEST_F(BfacfStepTest, SquareInitializesFromNewsud)
+{
+   init("enws", 42);
+   EXPECT_EQ(knot->writeAsNewsud(), "enws");
+}
+
+TEST_F(BfacfStepTest, RectangleInitializesFromNewsud)
+{
+   init("eennwwss", 42);
+   EXPECT_EQ(knot->writeAsNewsud(), "eennwwss");
+}
+
+TEST_F(BfacfStepTest, SquareSeed2Step0GrowsByTwo)
+{
+   // seed 2: first step grows enws -> enwwse (+2)
+   init("enws", 2);
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+}
+
+TEST_F(BfacfStepTest, SquareSeed2ThreeStepsShrinks)
+{
+   // seed 2: step 0: enws -> enwwse (+2)
+   //         step 1: enwwse -> enwwse (0)
+   //         step 2: enwwse -> enwwse (0)
+   //         step 3: enwwse -> enws (-2)
+   init("enws", 2);
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enws");
+}
+
+TEST_F(BfacfStepTest, RectangleSeed42FirstStepGrows)
+{
+   // seed 42: first step grows eennwwss -> euennwwssd (+2, into z dimension)
+   init("eennwwss", 42);
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "euennwwssd");
+}
+
+TEST_F(BfacfStepTest, RectangleSeed2TrajectoryToSquare)
+{
+   // seed 2: rectangle shrinks back to a square over 8 steps
+   //   step 0: eennwwss -> eennwwss (0)
+   //   step 1: eennwwss -> sennwwse (0, different start vertex)
+   //   step 2: sennwwse -> sennwwse (0)
+   //   step 3: sennwwse -> sennwwse (0)
+   //   step 4: sennwwse -> enwwse   (-2)
+   //   step 5: enwwse   -> enwwse   (0)
+   //   step 6: enwwse   -> enwwse   (0)
+   //   step 7: enwwse   -> enwwse   (0)
+   //   step 8: enwwse   -> enws     (-2, back to square)
+   init("eennwwss", 2);
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "eennwwss");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "sennwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "sennwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "sennwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwwse");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enws");
+}
+
+TEST_F(BfacfStepTest, SquareSeed1GrowsIntoZDimension)
+{
+   // seed 1: steps 0-5 are no-ops, step 6 grows into z
+   //         enws -> enwusd (+2)
+   init("enws", 1);
+   for (int i = 0; i < 6; i++)
+      knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enws");
+   knot->step();
+   EXPECT_EQ(knot->writeAsNewsud(), "enwusd");
+}
+
+TEST_F(BfacfStepTest, NeverShrinksBelowFourVertices)
+{
+   init("enws", 2);
+   for (int i = 0; i < 200; i++)
+   {
+      knot->step();
+      EXPECT_GE((int)knot->writeAsNewsud().length(), 4) << "step " << i;
+   }
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(unitTest
         clk_test.cpp
+        newsud_test.cpp
         pseudorandom_test.cpp
         recombo_criteria_test.cpp)
 target_link_libraries(unitTest recombo_core gtest gtest_main)

--- a/test/unit/newsud_test.cpp
+++ b/test/unit/newsud_test.cpp
@@ -2,6 +2,7 @@
 
 #include "clkConformationAsList.h"
 #include "clkCigar.h"
+#include "newsud.h"
 #include "threevector.h"
 
 static void expectVertex(const clk& k, int index, int x, int y, int z)
@@ -12,6 +13,151 @@ static void expectVertex(const clk& k, int index, int x, int y, int z)
    EXPECT_EQ(v.getY(), y) << "vertex " << index << " y";
    EXPECT_EQ(v.getZ(), z) << "vertex " << index << " z";
 }
+
+static void expectVertex(const std::vector<threevector<int> >& verts, int index, int x, int y, int z)
+{
+   EXPECT_EQ(verts[index].getX(), x) << "vertex " << index << " x";
+   EXPECT_EQ(verts[index].getY(), y) << "vertex " << index << " y";
+   EXPECT_EQ(verts[index].getZ(), z) << "vertex " << index << " z";
+}
+
+// newsudStep tests
+
+TEST(NewsudTest, StepEast)
+{
+   int dx, dy, dz;
+   EXPECT_TRUE(newsudStep('e', dx, dy, dz));
+   EXPECT_EQ(dx, 1); EXPECT_EQ(dy, 0); EXPECT_EQ(dz, 0);
+}
+
+TEST(NewsudTest, StepWest)
+{
+   int dx, dy, dz;
+   EXPECT_TRUE(newsudStep('w', dx, dy, dz));
+   EXPECT_EQ(dx, -1); EXPECT_EQ(dy, 0); EXPECT_EQ(dz, 0);
+}
+
+TEST(NewsudTest, StepNorth)
+{
+   int dx, dy, dz;
+   EXPECT_TRUE(newsudStep('n', dx, dy, dz));
+   EXPECT_EQ(dx, 0); EXPECT_EQ(dy, 1); EXPECT_EQ(dz, 0);
+}
+
+TEST(NewsudTest, StepSouth)
+{
+   int dx, dy, dz;
+   EXPECT_TRUE(newsudStep('s', dx, dy, dz));
+   EXPECT_EQ(dx, 0); EXPECT_EQ(dy, -1); EXPECT_EQ(dz, 0);
+}
+
+TEST(NewsudTest, StepUp)
+{
+   int dx, dy, dz;
+   EXPECT_TRUE(newsudStep('u', dx, dy, dz));
+   EXPECT_EQ(dx, 0); EXPECT_EQ(dy, 0); EXPECT_EQ(dz, 1);
+}
+
+TEST(NewsudTest, StepDown)
+{
+   int dx, dy, dz;
+   EXPECT_TRUE(newsudStep('d', dx, dy, dz));
+   EXPECT_EQ(dx, 0); EXPECT_EQ(dy, 0); EXPECT_EQ(dz, -1);
+}
+
+TEST(NewsudTest, StepInvalid)
+{
+   int dx, dy, dz;
+   EXPECT_FALSE(newsudStep('x', dx, dy, dz));
+}
+
+// newsudToVertices tests
+
+TEST(NewsudTest, ToVerticesSquare)
+{
+   std::vector<threevector<int> > v = newsudToVertices("enws");
+   ASSERT_EQ(v.size(), 4);
+   expectVertex(v, 0, 0, 0, 0);
+   expectVertex(v, 1, 1, 0, 0);
+   expectVertex(v, 2, 1, 1, 0);
+   expectVertex(v, 3, 0, 1, 0);
+}
+
+TEST(NewsudTest, ToVerticesWithOffset)
+{
+   std::vector<threevector<int> > v = newsudToVertices("enws", 5, 10, 3);
+   ASSERT_EQ(v.size(), 4);
+   expectVertex(v, 0, 5, 10, 3);
+   expectVertex(v, 1, 6, 10, 3);
+   expectVertex(v, 2, 6, 11, 3);
+   expectVertex(v, 3, 5, 11, 3);
+}
+
+TEST(NewsudTest, ToVerticesEmpty)
+{
+   std::vector<threevector<int> > v = newsudToVertices("");
+   ASSERT_EQ(v.size(), 1);
+   expectVertex(v, 0, 0, 0, 0);
+}
+
+TEST(NewsudTest, ToVerticesInvalid)
+{
+   std::vector<threevector<int> > v = newsudToVertices("enxw");
+   EXPECT_TRUE(v.empty());
+}
+
+// newsudIsClosed tests
+
+TEST(NewsudTest, ClosedSquare)
+{
+   EXPECT_TRUE(newsudIsClosed("enws"));
+}
+
+TEST(NewsudTest, ClosedRectangle)
+{
+   EXPECT_TRUE(newsudIsClosed("eennwwss"));
+}
+
+TEST(NewsudTest, ClosedWithUpDown)
+{
+   EXPECT_TRUE(newsudIsClosed("eundws"));
+}
+
+TEST(NewsudTest, NotClosed)
+{
+   EXPECT_FALSE(newsudIsClosed("enn"));
+}
+
+TEST(NewsudTest, ClosedEmpty)
+{
+   EXPECT_TRUE(newsudIsClosed(""));
+}
+
+// newsudIsSelfAvoiding tests
+
+TEST(NewsudTest, SelfAvoidingSquare)
+{
+   EXPECT_TRUE(newsudIsSelfAvoiding("enws"));
+}
+
+TEST(NewsudTest, SelfAvoidingRectangle)
+{
+   EXPECT_TRUE(newsudIsSelfAvoiding("eennwwss"));
+}
+
+TEST(NewsudTest, NotSelfAvoiding)
+{
+   EXPECT_FALSE(newsudIsSelfAvoiding("ews"));
+}
+
+TEST(NewsudTest, SelfAvoidingBacktrack)
+{
+   // e then w returns to start, which for a closed polygon is only
+   // a self-intersection if it's not the closing step
+   EXPECT_FALSE(newsudIsSelfAvoiding("ewenws"));
+}
+
+// clkConformationAsList read/write tests
 
 TEST(NewsudTest, WriteLengthEqualsVertexCount)
 {

--- a/test/unit/newsud_test.cpp
+++ b/test/unit/newsud_test.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include "clkConformationAsList.h"
+#include "clkCigar.h"
+#include "threevector.h"
+
+static void expectVertex(const clk& k, int index, int x, int y, int z)
+{
+   threevector<int> v;
+   k.getVertex(index, v);
+   EXPECT_EQ(v.getX(), x) << "vertex " << index << " x";
+   EXPECT_EQ(v.getY(), y) << "vertex " << index << " y";
+   EXPECT_EQ(v.getZ(), z) << "vertex " << index << " z";
+}
+
+TEST(NewsudTest, WriteLengthEqualsVertexCount)
+{
+   clkCigar square;
+   clkConformationAsList asList(square);
+   EXPECT_EQ(asList.writeAsNewsud().length(), asList.size());
+
+   clkCigar cigar6(6);
+   clkConformationAsList asList6(cigar6);
+   EXPECT_EQ(asList6.writeAsNewsud().length(), asList6.size());
+
+   clkCigar cigar10(10);
+   clkConformationAsList asList10(cigar10);
+   EXPECT_EQ(asList10.writeAsNewsud().length(), asList10.size());
+}
+
+TEST(NewsudTest, ReadLengthEqualsStringLength)
+{
+   clkConformationAsList k;
+   k.readFromNewsud("enws");
+   EXPECT_EQ(k.size(), 4);
+
+   k.readFromNewsud("eennwwss");
+   EXPECT_EQ(k.size(), 8);
+}
+
+TEST(NewsudTest, WriteSquare)
+{
+   clkCigar square;
+   clkConformationAsList asList(square);
+   EXPECT_EQ(asList.writeAsNewsud(), "enws");
+}
+
+TEST(NewsudTest, WriteCigar6)
+{
+   clkCigar cigar(6);
+   clkConformationAsList asList(cigar);
+   EXPECT_EQ(asList.writeAsNewsud(), "eenwws");
+}
+
+TEST(NewsudTest, ReadSquare)
+{
+   clkConformationAsList k;
+   EXPECT_TRUE(k.readFromNewsud("enws"));
+   ASSERT_EQ(k.size(), 4);
+   expectVertex(k, 0, 0, 0, 0);
+   expectVertex(k, 1, 1, 0, 0);
+   expectVertex(k, 2, 1, 1, 0);
+   expectVertex(k, 3, 0, 1, 0);
+}
+
+TEST(NewsudTest, ReadWithStartingCoords)
+{
+   clkConformationAsList k;
+   EXPECT_TRUE(k.readFromNewsud("enws", 5, 10, 3));
+   ASSERT_EQ(k.size(), 4);
+   expectVertex(k, 0, 5, 10, 3);
+   expectVertex(k, 1, 6, 10, 3);
+   expectVertex(k, 2, 6, 11, 3);
+   expectVertex(k, 3, 5, 11, 3);
+}
+
+TEST(NewsudTest, RoundTrip)
+{
+   clkConformationAsList k;
+   k.readFromNewsud("eennwwss");
+   std::string result = k.writeAsNewsud();
+   EXPECT_EQ(result, "eennwwss");
+}
+
+TEST(NewsudTest, RoundTripWithOffset)
+{
+   clkConformationAsList k;
+   k.readFromNewsud("ensw", 3, 4, 5);
+   clkConformationAsList k2(k);
+   EXPECT_EQ(k2.writeAsNewsud(), "ensw");
+}
+
+TEST(NewsudTest, ReadWithUpDown)
+{
+   clkConformationAsList k;
+   EXPECT_TRUE(k.readFromNewsud("eudn"));
+   ASSERT_EQ(k.size(), 4);
+   expectVertex(k, 0, 0, 0, 0);
+   expectVertex(k, 1, 1, 0, 0);
+   expectVertex(k, 2, 1, 0, 1);
+   expectVertex(k, 3, 1, 0, 0);
+}
+
+TEST(NewsudTest, InvalidCharacter)
+{
+   clkConformationAsList k;
+   EXPECT_FALSE(k.readFromNewsud("enxw"));
+}
+
+TEST(NewsudTest, EmptyString)
+{
+   clkConformationAsList k;
+   EXPECT_TRUE(k.readFromNewsud(""));
+   EXPECT_EQ(k.size(), 1);
+}


### PR DESCRIPTION
 - Implemented the long-planned newsud direction string representation         
  (`writeAsNewsud`, `readFromNewsud`, newsud constructor) — these were TODO     
  items in `clkConformationAsList.h` since 2012
  - Extracted shared newsud primitives (`newsudStep`, `newsudToVertices`,       
  `newsudIsClosed`, `newsudIsSelfAvoiding`) into `src/newsud.h`/`src/newsud.cpp`
  - Added `clkConformationBfacf3::writeAsNewsud()` for convenient access to
  component direction strings                                                   
  - Added unit tests for all newsud primitives and conversion utilities (31     
  tests in `newsud_test.cpp`)                 
  - Added BFACF step regression tests using newsud strings                      
  (`bfacf_step_test.cpp`), verifying exact conformation strings at each step
  rather than vertex lists                                                      
  - The newsud representation makes BFACF test assertions compact and
  human-verifiable — e.g., a reviewer can read `"eennwwss" -> "sennwwse" ->     
  "enwwse" -> "enws"` and see the polygon shrinking