### PR TITLE
Fix merge issue

### DIFF
--- a/test/regression/writhe_test.cpp
+++ b/test/regression/writhe_test.cpp
@@ -5,6 +5,7 @@
 
 #include "clkConformationAsList.h"
 #include "legacy.h"
+#include "writhe.h"
 
 using namespace std;
 


### PR DESCRIPTION
The last three PRs all worked separately, but when merged together they broke. The writhe tests needed `#include "writhe.h"` since the cleanup branch moved those functions out of `legacy.h`. After adding that 93 tests pass again.
