### PR TITLE
fix: rng initialization, logging, and consistent handling in implementation

### DIFF
--- a/src/mmchain.cpp
+++ b/src/mmchain.cpp
@@ -26,11 +26,9 @@ void mmchain::initialize(const MmcConfig& config) {
 	m = config.num_chains;
 	w = config.warmup_steps;
 	seed = config.seed;
-	if (seed)
-		srand(seed);
-	else {
+	if (!seed)
 		seed = time(NULL);
-	};
+	srand(seed);
 	add_initial_conformation_from_file(infile);
 	block_file_size = config.block_file_size;
 	block_file_index = 0;
@@ -55,13 +53,13 @@ bool mmchain::add_initial_conformation(istream& is){
    if (n_components == 2){
 	   for(i=0; i<m; i++){
 		   tempChain.member_knot = new clkConformationBfacf3(initialComp0, initialComp1);
-		   tempChain.member_knot->setSeed(time(NULL)); //what is this doing? PRESERVED(->setSeed(m+rand());)
+		   tempChain.member_knot->setSeed(m+rand());
 		   chains.push_back(tempChain);
 	   }}
    else if (n_components == 1){
 		for (i=0;i<m;i++){
 			tempChain.member_knot = new clkConformationBfacf3(initialComp0);
-			tempChain.member_knot->setSeed(m+rand()); //what is this actually doing though?
+			tempChain.member_knot->setSeed(m+rand());
 			chains.push_back(tempChain);
 		}}
 


### PR DESCRIPTION
Summary                                                                 
                                                                                                                                               
  - Fix seed propagation so the logged seed value is always the seed actually used, making runs fully reproducible                             
  - When seed is unspecified (0), resolve to time(NULL) first, then always call srand() — previously srand() was skipped entirely in this case,
   leaving the system RNG in its default state while logging a time(NULL) value that wasn't used downstream                                    
  - Unify 2-component link chain seeding to use setSeed(m+rand()) instead of setSeed(time(NULL)) — the old code made an independent time(NULL) 
  call per chain, ignoring the master seed and making 2-component link runs non-reproducible even when a seed was explicitly provided          
                                                                                                                                               
  Test plan                                                                                                                                    
                                                                                                                                               
  - 93/93 unit and regression tests pass                                                                                                     
  - 1-component (knot): replaying logged seed twice produces byte-identical .b output                                                          
  - 2-component (link): replaying seed 42 on initial/2_2_1a twice produces byte-identical .b output — this was the broken path before the fix