### PR TITLE
feat: config as json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(recombo_core STATIC
         src/conformationAsList.cpp
         src/conformationWlc.cpp
         src/id.cpp
+        src/json11.cpp
         src/legacy.cpp
         src/legacyBfacf.cpp
         src/mmc_config.cpp
@@ -35,7 +36,8 @@ add_library(recombo_core STATIC
         src/writhe.cpp
         src/pseudorandom.cpp
         src/regularNgon.cpp
-        src/zAnalyzer.cpp)
+        src/zAnalyzer.cpp
+        src/zanalyzer_config.cpp)
 target_include_directories(recombo_core PUBLIC src)
 
 # Executables

--- a/src/json11.cpp
+++ b/src/json11.cpp
@@ -1,0 +1,790 @@
+/* Copyright (c) 2013 Dropbox, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "json11.hpp"
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <cstdio>
+#include <limits>
+
+namespace json11 {
+
+static const int max_depth = 200;
+
+using std::string;
+using std::vector;
+using std::map;
+using std::make_shared;
+using std::initializer_list;
+using std::move;
+
+/* Helper for representing null - just a do-nothing struct, plus comparison
+ * operators so the helpers in JsonValue work. We can't use nullptr_t because
+ * it may not be orderable.
+ */
+struct NullStruct {
+    bool operator==(NullStruct) const { return true; }
+    bool operator<(NullStruct) const { return false; }
+};
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Serialization
+ */
+
+static void dump(NullStruct, string &out) {
+    out += "null";
+}
+
+static void dump(double value, string &out) {
+    if (std::isfinite(value)) {
+        char buf[32];
+        snprintf(buf, sizeof buf, "%.17g", value);
+        out += buf;
+    } else {
+        out += "null";
+    }
+}
+
+static void dump(int value, string &out) {
+    char buf[32];
+    snprintf(buf, sizeof buf, "%d", value);
+    out += buf;
+}
+
+static void dump(bool value, string &out) {
+    out += value ? "true" : "false";
+}
+
+static void dump(const string &value, string &out) {
+    out += '"';
+    for (size_t i = 0; i < value.length(); i++) {
+        const char ch = value[i];
+        if (ch == '\\') {
+            out += "\\\\";
+        } else if (ch == '"') {
+            out += "\\\"";
+        } else if (ch == '\b') {
+            out += "\\b";
+        } else if (ch == '\f') {
+            out += "\\f";
+        } else if (ch == '\n') {
+            out += "\\n";
+        } else if (ch == '\r') {
+            out += "\\r";
+        } else if (ch == '\t') {
+            out += "\\t";
+        } else if (static_cast<uint8_t>(ch) <= 0x1f) {
+            char buf[8];
+            snprintf(buf, sizeof buf, "\\u%04x", ch);
+            out += buf;
+        } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
+                   && static_cast<uint8_t>(value[i+2]) == 0xa8) {
+            out += "\\u2028";
+            i += 2;
+        } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
+                   && static_cast<uint8_t>(value[i+2]) == 0xa9) {
+            out += "\\u2029";
+            i += 2;
+        } else {
+            out += ch;
+        }
+    }
+    out += '"';
+}
+
+static void dump(const Json::array &values, string &out) {
+    bool first = true;
+    out += "[";
+    for (const auto &value : values) {
+        if (!first)
+            out += ", ";
+        value.dump(out);
+        first = false;
+    }
+    out += "]";
+}
+
+static void dump(const Json::object &values, string &out) {
+    bool first = true;
+    out += "{";
+    for (const auto &kv : values) {
+        if (!first)
+            out += ", ";
+        dump(kv.first, out);
+        out += ": ";
+        kv.second.dump(out);
+        first = false;
+    }
+    out += "}";
+}
+
+void Json::dump(string &out) const {
+    m_ptr->dump(out);
+}
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Value wrappers
+ */
+
+template <Json::Type tag, typename T>
+class Value : public JsonValue {
+protected:
+
+    // Constructors
+    explicit Value(const T &value) : m_value(value) {}
+    explicit Value(T &&value)      : m_value(move(value)) {}
+
+    // Get type tag
+    Json::Type type() const override {
+        return tag;
+    }
+
+    // Comparisons
+    bool equals(const JsonValue * other) const override {
+        return m_value == static_cast<const Value<tag, T> *>(other)->m_value;
+    }
+    bool less(const JsonValue * other) const override {
+        return m_value < static_cast<const Value<tag, T> *>(other)->m_value;
+    }
+
+    const T m_value;
+    void dump(string &out) const override { json11::dump(m_value, out); }
+};
+
+class JsonDouble final : public Value<Json::NUMBER, double> {
+    double number_value() const override { return m_value; }
+    int int_value() const override { return static_cast<int>(m_value); }
+    bool equals(const JsonValue * other) const override { return m_value == other->number_value(); }
+    bool less(const JsonValue * other)   const override { return m_value <  other->number_value(); }
+public:
+    explicit JsonDouble(double value) : Value(value) {}
+};
+
+class JsonInt final : public Value<Json::NUMBER, int> {
+    double number_value() const override { return m_value; }
+    int int_value() const override { return m_value; }
+    bool equals(const JsonValue * other) const override { return m_value == other->number_value(); }
+    bool less(const JsonValue * other)   const override { return m_value <  other->number_value(); }
+public:
+    explicit JsonInt(int value) : Value(value) {}
+};
+
+class JsonBoolean final : public Value<Json::BOOL, bool> {
+    bool bool_value() const override { return m_value; }
+public:
+    explicit JsonBoolean(bool value) : Value(value) {}
+};
+
+class JsonString final : public Value<Json::STRING, string> {
+    const string &string_value() const override { return m_value; }
+public:
+    explicit JsonString(const string &value) : Value(value) {}
+    explicit JsonString(string &&value)      : Value(move(value)) {}
+};
+
+class JsonArray final : public Value<Json::ARRAY, Json::array> {
+    const Json::array &array_items() const override { return m_value; }
+    const Json & operator[](size_t i) const override;
+public:
+    explicit JsonArray(const Json::array &value) : Value(value) {}
+    explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
+};
+
+class JsonObject final : public Value<Json::OBJECT, Json::object> {
+    const Json::object &object_items() const override { return m_value; }
+    const Json & operator[](const string &key) const override;
+public:
+    explicit JsonObject(const Json::object &value) : Value(value) {}
+    explicit JsonObject(Json::object &&value)      : Value(move(value)) {}
+};
+
+class JsonNull final : public Value<Json::NUL, NullStruct> {
+public:
+    JsonNull() : Value({}) {}
+};
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Static globals - static-init-safe
+ */
+struct Statics {
+    const std::shared_ptr<JsonValue> null = make_shared<JsonNull>();
+    const std::shared_ptr<JsonValue> t = make_shared<JsonBoolean>(true);
+    const std::shared_ptr<JsonValue> f = make_shared<JsonBoolean>(false);
+    const string empty_string;
+    const vector<Json> empty_vector;
+    const map<string, Json> empty_map;
+    Statics() {}
+};
+
+static const Statics & statics() {
+    static const Statics s {};
+    return s;
+}
+
+static const Json & static_null() {
+    // This has to be separate, not in Statics, because Json() accesses statics().null.
+    static const Json json_null;
+    return json_null;
+}
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Constructors
+ */
+
+Json::Json() noexcept                  : m_ptr(statics().null) {}
+Json::Json(std::nullptr_t) noexcept    : m_ptr(statics().null) {}
+Json::Json(double value)               : m_ptr(make_shared<JsonDouble>(value)) {}
+Json::Json(int value)                  : m_ptr(make_shared<JsonInt>(value)) {}
+Json::Json(bool value)                 : m_ptr(value ? statics().t : statics().f) {}
+Json::Json(const string &value)        : m_ptr(make_shared<JsonString>(value)) {}
+Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(move(value))) {}
+Json::Json(const char * value)         : m_ptr(make_shared<JsonString>(value)) {}
+Json::Json(const Json::array &values)  : m_ptr(make_shared<JsonArray>(values)) {}
+Json::Json(Json::array &&values)       : m_ptr(make_shared<JsonArray>(move(values))) {}
+Json::Json(const Json::object &values) : m_ptr(make_shared<JsonObject>(values)) {}
+Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(move(values))) {}
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Accessors
+ */
+
+Json::Type Json::type()                           const { return m_ptr->type();         }
+double Json::number_value()                       const { return m_ptr->number_value(); }
+int Json::int_value()                             const { return m_ptr->int_value();    }
+bool Json::bool_value()                           const { return m_ptr->bool_value();   }
+const string & Json::string_value()               const { return m_ptr->string_value(); }
+const vector<Json> & Json::array_items()          const { return m_ptr->array_items();  }
+const map<string, Json> & Json::object_items()    const { return m_ptr->object_items(); }
+const Json & Json::operator[] (size_t i)          const { return (*m_ptr)[i];           }
+const Json & Json::operator[] (const string &key) const { return (*m_ptr)[key];         }
+
+double                    JsonValue::number_value()              const { return 0; }
+int                       JsonValue::int_value()                 const { return 0; }
+bool                      JsonValue::bool_value()                const { return false; }
+const string &            JsonValue::string_value()              const { return statics().empty_string; }
+const vector<Json> &      JsonValue::array_items()               const { return statics().empty_vector; }
+const map<string, Json> & JsonValue::object_items()              const { return statics().empty_map; }
+const Json &              JsonValue::operator[] (size_t)         const { return static_null(); }
+const Json &              JsonValue::operator[] (const string &) const { return static_null(); }
+
+const Json & JsonObject::operator[] (const string &key) const {
+    auto iter = m_value.find(key);
+    return (iter == m_value.end()) ? static_null() : iter->second;
+}
+const Json & JsonArray::operator[] (size_t i) const {
+    if (i >= m_value.size()) return static_null();
+    else return m_value[i];
+}
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Comparison
+ */
+
+bool Json::operator== (const Json &other) const {
+    if (m_ptr == other.m_ptr)
+        return true;
+    if (m_ptr->type() != other.m_ptr->type())
+        return false;
+
+    return m_ptr->equals(other.m_ptr.get());
+}
+
+bool Json::operator< (const Json &other) const {
+    if (m_ptr == other.m_ptr)
+        return false;
+    if (m_ptr->type() != other.m_ptr->type())
+        return m_ptr->type() < other.m_ptr->type();
+
+    return m_ptr->less(other.m_ptr.get());
+}
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Parsing
+ */
+
+/* esc(c)
+ *
+ * Format char c suitable for printing in an error message.
+ */
+static inline string esc(char c) {
+    char buf[12];
+    if (static_cast<uint8_t>(c) >= 0x20 && static_cast<uint8_t>(c) <= 0x7f) {
+        snprintf(buf, sizeof buf, "'%c' (%d)", c, c);
+    } else {
+        snprintf(buf, sizeof buf, "(%d)", c);
+    }
+    return string(buf);
+}
+
+static inline bool in_range(long x, long lower, long upper) {
+    return (x >= lower && x <= upper);
+}
+
+namespace {
+/* JsonParser
+ *
+ * Object that tracks all state of an in-progress parse.
+ */
+struct JsonParser final {
+
+    /* State
+     */
+    const string &str;
+    size_t i;
+    string &err;
+    bool failed;
+    const JsonParse strategy;
+
+    /* fail(msg, err_ret = Json())
+     *
+     * Mark this parse as failed.
+     */
+    Json fail(string &&msg) {
+        return fail(move(msg), Json());
+    }
+
+    template <typename T>
+    T fail(string &&msg, const T err_ret) {
+        if (!failed)
+            err = std::move(msg);
+        failed = true;
+        return err_ret;
+    }
+
+    /* consume_whitespace()
+     *
+     * Advance until the current character is non-whitespace.
+     */
+    void consume_whitespace() {
+        while (str[i] == ' ' || str[i] == '\r' || str[i] == '\n' || str[i] == '\t')
+            i++;
+    }
+
+    /* consume_comment()
+     *
+     * Advance comments (c-style inline and multiline).
+     */
+    bool consume_comment() {
+      bool comment_found = false;
+      if (str[i] == '/') {
+        i++;
+        if (i == str.size())
+          return fail("unexpected end of input after start of comment", false);
+        if (str[i] == '/') { // inline comment
+          i++;
+          // advance until next line, or end of input
+          while (i < str.size() && str[i] != '\n') {
+            i++;
+          }
+          comment_found = true;
+        }
+        else if (str[i] == '*') { // multiline comment
+          i++;
+          if (i > str.size()-2)
+            return fail("unexpected end of input inside multi-line comment", false);
+          // advance until closing tokens
+          while (!(str[i] == '*' && str[i+1] == '/')) {
+            i++;
+            if (i > str.size()-2)
+              return fail(
+                "unexpected end of input inside multi-line comment", false);
+          }
+          i += 2;
+          comment_found = true;
+        }
+        else
+          return fail("malformed comment", false);
+      }
+      return comment_found;
+    }
+
+    /* consume_garbage()
+     *
+     * Advance until the current character is non-whitespace and non-comment.
+     */
+    void consume_garbage() {
+      consume_whitespace();
+      if(strategy == JsonParse::COMMENTS) {
+        bool comment_found = false;
+        do {
+          comment_found = consume_comment();
+          if (failed) return;
+          consume_whitespace();
+        }
+        while(comment_found);
+      }
+    }
+
+    /* get_next_token()
+     *
+     * Return the next non-whitespace character. If the end of the input is reached,
+     * flag an error and return 0.
+     */
+    char get_next_token() {
+        consume_garbage();
+        if (failed) return static_cast<char>(0);
+        if (i == str.size())
+            return fail("unexpected end of input", static_cast<char>(0));
+
+        return str[i++];
+    }
+
+    /* encode_utf8(pt, out)
+     *
+     * Encode pt as UTF-8 and add it to out.
+     */
+    void encode_utf8(long pt, string & out) {
+        if (pt < 0)
+            return;
+
+        if (pt < 0x80) {
+            out += static_cast<char>(pt);
+        } else if (pt < 0x800) {
+            out += static_cast<char>((pt >> 6) | 0xC0);
+            out += static_cast<char>((pt & 0x3F) | 0x80);
+        } else if (pt < 0x10000) {
+            out += static_cast<char>((pt >> 12) | 0xE0);
+            out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
+            out += static_cast<char>((pt & 0x3F) | 0x80);
+        } else {
+            out += static_cast<char>((pt >> 18) | 0xF0);
+            out += static_cast<char>(((pt >> 12) & 0x3F) | 0x80);
+            out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
+            out += static_cast<char>((pt & 0x3F) | 0x80);
+        }
+    }
+
+    /* parse_string()
+     *
+     * Parse a string, starting at the current position.
+     */
+    string parse_string() {
+        string out;
+        long last_escaped_codepoint = -1;
+        while (true) {
+            if (i == str.size())
+                return fail("unexpected end of input in string", "");
+
+            char ch = str[i++];
+
+            if (ch == '"') {
+                encode_utf8(last_escaped_codepoint, out);
+                return out;
+            }
+
+            if (in_range(ch, 0, 0x1f))
+                return fail("unescaped " + esc(ch) + " in string", "");
+
+            // The usual case: non-escaped characters
+            if (ch != '\\') {
+                encode_utf8(last_escaped_codepoint, out);
+                last_escaped_codepoint = -1;
+                out += ch;
+                continue;
+            }
+
+            // Handle escapes
+            if (i == str.size())
+                return fail("unexpected end of input in string", "");
+
+            ch = str[i++];
+
+            if (ch == 'u') {
+                // Extract 4-byte escape sequence
+                string esc = str.substr(i, 4);
+                // Explicitly check length of the substring. The following loop
+                // relies on std::string returning the terminating NUL when
+                // accessing str[length]. Checking here reduces brittleness.
+                if (esc.length() < 4) {
+                    return fail("bad \\u escape: " + esc, "");
+                }
+                for (size_t j = 0; j < 4; j++) {
+                    if (!in_range(esc[j], 'a', 'f') && !in_range(esc[j], 'A', 'F')
+                            && !in_range(esc[j], '0', '9'))
+                        return fail("bad \\u escape: " + esc, "");
+                }
+
+                long codepoint = strtol(esc.data(), nullptr, 16);
+
+                // JSON specifies that characters outside the BMP shall be encoded as a pair
+                // of 4-hex-digit \u escapes encoding their surrogate pair components. Check
+                // whether we're in the middle of such a beast: the previous codepoint was an
+                // escaped lead (high) surrogate, and this is a trail (low) surrogate.
+                if (in_range(last_escaped_codepoint, 0xD800, 0xDBFF)
+                        && in_range(codepoint, 0xDC00, 0xDFFF)) {
+                    // Reassemble the two surrogate pairs into one astral-plane character, per
+                    // the UTF-16 algorithm.
+                    encode_utf8((((last_escaped_codepoint - 0xD800) << 10)
+                                 | (codepoint - 0xDC00)) + 0x10000, out);
+                    last_escaped_codepoint = -1;
+                } else {
+                    encode_utf8(last_escaped_codepoint, out);
+                    last_escaped_codepoint = codepoint;
+                }
+
+                i += 4;
+                continue;
+            }
+
+            encode_utf8(last_escaped_codepoint, out);
+            last_escaped_codepoint = -1;
+
+            if (ch == 'b') {
+                out += '\b';
+            } else if (ch == 'f') {
+                out += '\f';
+            } else if (ch == 'n') {
+                out += '\n';
+            } else if (ch == 'r') {
+                out += '\r';
+            } else if (ch == 't') {
+                out += '\t';
+            } else if (ch == '"' || ch == '\\' || ch == '/') {
+                out += ch;
+            } else {
+                return fail("invalid escape character " + esc(ch), "");
+            }
+        }
+    }
+
+    /* parse_number()
+     *
+     * Parse a double.
+     */
+    Json parse_number() {
+        size_t start_pos = i;
+
+        if (str[i] == '-')
+            i++;
+
+        // Integer part
+        if (str[i] == '0') {
+            i++;
+            if (in_range(str[i], '0', '9'))
+                return fail("leading 0s not permitted in numbers");
+        } else if (in_range(str[i], '1', '9')) {
+            i++;
+            while (in_range(str[i], '0', '9'))
+                i++;
+        } else {
+            return fail("invalid " + esc(str[i]) + " in number");
+        }
+
+        if (str[i] != '.' && str[i] != 'e' && str[i] != 'E'
+                && (i - start_pos) <= static_cast<size_t>(std::numeric_limits<int>::digits10)) {
+            return std::atoi(str.c_str() + start_pos);
+        }
+
+        // Decimal part
+        if (str[i] == '.') {
+            i++;
+            if (!in_range(str[i], '0', '9'))
+                return fail("at least one digit required in fractional part");
+
+            while (in_range(str[i], '0', '9'))
+                i++;
+        }
+
+        // Exponent part
+        if (str[i] == 'e' || str[i] == 'E') {
+            i++;
+
+            if (str[i] == '+' || str[i] == '-')
+                i++;
+
+            if (!in_range(str[i], '0', '9'))
+                return fail("at least one digit required in exponent");
+
+            while (in_range(str[i], '0', '9'))
+                i++;
+        }
+
+        return std::strtod(str.c_str() + start_pos, nullptr);
+    }
+
+    /* expect(str, res)
+     *
+     * Expect that 'str' starts at the character that was just read. If it does, advance
+     * the input and return res. If not, flag an error.
+     */
+    Json expect(const string &expected, Json res) {
+        assert(i != 0);
+        i--;
+        if (str.compare(i, expected.length(), expected) == 0) {
+            i += expected.length();
+            return res;
+        } else {
+            return fail("parse error: expected " + expected + ", got " + str.substr(i, expected.length()));
+        }
+    }
+
+    /* parse_json()
+     *
+     * Parse a JSON object.
+     */
+    Json parse_json(int depth) {
+        if (depth > max_depth) {
+            return fail("exceeded maximum nesting depth");
+        }
+
+        char ch = get_next_token();
+        if (failed)
+            return Json();
+
+        if (ch == '-' || (ch >= '0' && ch <= '9')) {
+            i--;
+            return parse_number();
+        }
+
+        if (ch == 't')
+            return expect("true", true);
+
+        if (ch == 'f')
+            return expect("false", false);
+
+        if (ch == 'n')
+            return expect("null", Json());
+
+        if (ch == '"')
+            return parse_string();
+
+        if (ch == '{') {
+            map<string, Json> data;
+            ch = get_next_token();
+            if (ch == '}')
+                return data;
+
+            while (1) {
+                if (ch != '"')
+                    return fail("expected '\"' in object, got " + esc(ch));
+
+                string key = parse_string();
+                if (failed)
+                    return Json();
+
+                ch = get_next_token();
+                if (ch != ':')
+                    return fail("expected ':' in object, got " + esc(ch));
+
+                data[std::move(key)] = parse_json(depth + 1);
+                if (failed)
+                    return Json();
+
+                ch = get_next_token();
+                if (ch == '}')
+                    break;
+                if (ch != ',')
+                    return fail("expected ',' in object, got " + esc(ch));
+
+                ch = get_next_token();
+            }
+            return data;
+        }
+
+        if (ch == '[') {
+            vector<Json> data;
+            ch = get_next_token();
+            if (ch == ']')
+                return data;
+
+            while (1) {
+                i--;
+                data.push_back(parse_json(depth + 1));
+                if (failed)
+                    return Json();
+
+                ch = get_next_token();
+                if (ch == ']')
+                    break;
+                if (ch != ',')
+                    return fail("expected ',' in list, got " + esc(ch));
+
+                ch = get_next_token();
+                (void)ch;
+            }
+            return data;
+        }
+
+        return fail("expected value, got " + esc(ch));
+    }
+};
+}//namespace {
+
+Json Json::parse(const string &in, string &err, JsonParse strategy) {
+    JsonParser parser { in, 0, err, false, strategy };
+    Json result = parser.parse_json(0);
+
+    // Check for any trailing garbage
+    parser.consume_garbage();
+    if (parser.failed)
+        return Json();
+    if (parser.i != in.size())
+        return parser.fail("unexpected trailing " + esc(in[parser.i]));
+
+    return result;
+}
+
+// Documented in json11.hpp
+vector<Json> Json::parse_multi(const string &in,
+                               std::string::size_type &parser_stop_pos,
+                               string &err,
+                               JsonParse strategy) {
+    JsonParser parser { in, 0, err, false, strategy };
+    parser_stop_pos = 0;
+    vector<Json> json_vec;
+    while (parser.i != in.size() && !parser.failed) {
+        json_vec.push_back(parser.parse_json(0));
+        if (parser.failed)
+            break;
+
+        // Check for another object
+        parser.consume_garbage();
+        if (parser.failed)
+            break;
+        parser_stop_pos = parser.i;
+    }
+    return json_vec;
+}
+
+/* * * * * * * * * * * * * * * * * * * *
+ * Shape-checking
+ */
+
+bool Json::has_shape(const shape & types, string & err) const {
+    if (!is_object()) {
+        err = "expected JSON object, got " + dump();
+        return false;
+    }
+
+    const auto& obj_items = object_items();
+    for (auto & item : types) {
+        const auto it = obj_items.find(item.first);
+        if (it == obj_items.cend() || it->second.type() != item.second) {
+            err = "bad type for " + item.first + " in " + dump();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace json11

--- a/src/json11.hpp
+++ b/src/json11.hpp
@@ -1,0 +1,232 @@
+/* json11
+ *
+ * json11 is a tiny JSON library for C++11, providing JSON parsing and serialization.
+ *
+ * The core object provided by the library is json11::Json. A Json object represents any JSON
+ * value: null, bool, number (int or double), string (std::string), array (std::vector), or
+ * object (std::map).
+ *
+ * Json objects act like values: they can be assigned, copied, moved, compared for equality or
+ * order, etc. There are also helper methods Json::dump, to serialize a Json to a string, and
+ * Json::parse (static) to parse a std::string as a Json object.
+ *
+ * Internally, the various types of Json object are represented by the JsonValue class
+ * hierarchy.
+ *
+ * A note on numbers - JSON specifies the syntax of number formatting but not its semantics,
+ * so some JSON implementations distinguish between integers and floating-point numbers, while
+ * some don't. In json11, we choose the latter. Because some JSON implementations (namely
+ * Javascript itself) treat all numbers as the same type, distinguishing the two leads
+ * to JSON that will be *silently* changed by a round-trip through those implementations.
+ * Dangerous! To avoid that risk, json11 stores all numbers as double internally, but also
+ * provides integer helpers.
+ *
+ * Fortunately, double-precision IEEE754 ('double') can precisely store any integer in the
+ * range +/-2^53, which includes every 'int' on most systems. (Timestamps often use int64
+ * or long long to avoid the Y2038K problem; a double storing microseconds since some epoch
+ * will be exact for +/- 275 years.)
+ */
+
+/* Copyright (c) 2013 Dropbox, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+#include <initializer_list>
+
+#ifdef _MSC_VER
+    #if _MSC_VER <= 1800 // VS 2013
+        #ifndef noexcept
+            #define noexcept throw()
+        #endif
+
+        #ifndef snprintf
+            #define snprintf _snprintf_s
+        #endif
+    #endif
+#endif
+
+namespace json11 {
+
+enum JsonParse {
+    STANDARD, COMMENTS
+};
+
+class JsonValue;
+
+class Json final {
+public:
+    // Types
+    enum Type {
+        NUL, NUMBER, BOOL, STRING, ARRAY, OBJECT
+    };
+
+    // Array and object typedefs
+    typedef std::vector<Json> array;
+    typedef std::map<std::string, Json> object;
+
+    // Constructors for the various types of JSON value.
+    Json() noexcept;                // NUL
+    Json(std::nullptr_t) noexcept;  // NUL
+    Json(double value);             // NUMBER
+    Json(int value);                // NUMBER
+    Json(bool value);               // BOOL
+    Json(const std::string &value); // STRING
+    Json(std::string &&value);      // STRING
+    Json(const char * value);       // STRING
+    Json(const array &values);      // ARRAY
+    Json(array &&values);           // ARRAY
+    Json(const object &values);     // OBJECT
+    Json(object &&values);          // OBJECT
+
+    // Implicit constructor: anything with a to_json() function.
+    template <class T, class = decltype(&T::to_json)>
+    Json(const T & t) : Json(t.to_json()) {}
+
+    // Implicit constructor: map-like objects (std::map, std::unordered_map, etc)
+    template <class M, typename std::enable_if<
+        std::is_constructible<std::string, decltype(std::declval<M>().begin()->first)>::value
+        && std::is_constructible<Json, decltype(std::declval<M>().begin()->second)>::value,
+            int>::type = 0>
+    Json(const M & m) : Json(object(m.begin(), m.end())) {}
+
+    // Implicit constructor: vector-like objects (std::list, std::vector, std::set, etc)
+    template <class V, typename std::enable_if<
+        std::is_constructible<Json, decltype(*std::declval<V>().begin())>::value,
+            int>::type = 0>
+    Json(const V & v) : Json(array(v.begin(), v.end())) {}
+
+    // This prevents Json(some_pointer) from accidentally producing a bool. Use
+    // Json(bool(some_pointer)) if that behavior is desired.
+    Json(void *) = delete;
+
+    // Accessors
+    Type type() const;
+
+    bool is_null()   const { return type() == NUL; }
+    bool is_number() const { return type() == NUMBER; }
+    bool is_bool()   const { return type() == BOOL; }
+    bool is_string() const { return type() == STRING; }
+    bool is_array()  const { return type() == ARRAY; }
+    bool is_object() const { return type() == OBJECT; }
+
+    // Return the enclosed value if this is a number, 0 otherwise. Note that json11 does not
+    // distinguish between integer and non-integer numbers - number_value() and int_value()
+    // can both be applied to a NUMBER-typed object.
+    double number_value() const;
+    int int_value() const;
+
+    // Return the enclosed value if this is a boolean, false otherwise.
+    bool bool_value() const;
+    // Return the enclosed string if this is a string, "" otherwise.
+    const std::string &string_value() const;
+    // Return the enclosed std::vector if this is an array, or an empty vector otherwise.
+    const array &array_items() const;
+    // Return the enclosed std::map if this is an object, or an empty map otherwise.
+    const object &object_items() const;
+
+    // Return a reference to arr[i] if this is an array, Json() otherwise.
+    const Json & operator[](size_t i) const;
+    // Return a reference to obj[key] if this is an object, Json() otherwise.
+    const Json & operator[](const std::string &key) const;
+
+    // Serialize.
+    void dump(std::string &out) const;
+    std::string dump() const {
+        std::string out;
+        dump(out);
+        return out;
+    }
+
+    // Parse. If parse fails, return Json() and assign an error message to err.
+    static Json parse(const std::string & in,
+                      std::string & err,
+                      JsonParse strategy = JsonParse::STANDARD);
+    static Json parse(const char * in,
+                      std::string & err,
+                      JsonParse strategy = JsonParse::STANDARD) {
+        if (in) {
+            return parse(std::string(in), err, strategy);
+        } else {
+            err = "null input";
+            return nullptr;
+        }
+    }
+    // Parse multiple objects, concatenated or separated by whitespace
+    static std::vector<Json> parse_multi(
+        const std::string & in,
+        std::string::size_type & parser_stop_pos,
+        std::string & err,
+        JsonParse strategy = JsonParse::STANDARD);
+
+    static inline std::vector<Json> parse_multi(
+        const std::string & in,
+        std::string & err,
+        JsonParse strategy = JsonParse::STANDARD) {
+        std::string::size_type parser_stop_pos;
+        return parse_multi(in, parser_stop_pos, err, strategy);
+    }
+
+    bool operator== (const Json &rhs) const;
+    bool operator<  (const Json &rhs) const;
+    bool operator!= (const Json &rhs) const { return !(*this == rhs); }
+    bool operator<= (const Json &rhs) const { return !(rhs < *this); }
+    bool operator>  (const Json &rhs) const { return  (rhs < *this); }
+    bool operator>= (const Json &rhs) const { return !(*this < rhs); }
+
+    /* has_shape(types, err)
+     *
+     * Return true if this is a JSON object and, for each item in types, has a field of
+     * the given type. If not, return false and set err to a descriptive message.
+     */
+    typedef std::initializer_list<std::pair<std::string, Type>> shape;
+    bool has_shape(const shape & types, std::string & err) const;
+
+private:
+    std::shared_ptr<JsonValue> m_ptr;
+};
+
+// Internal class hierarchy - JsonValue objects are not exposed to users of this API.
+class JsonValue {
+protected:
+    friend class Json;
+    friend class JsonInt;
+    friend class JsonDouble;
+    virtual Json::Type type() const = 0;
+    virtual bool equals(const JsonValue * other) const = 0;
+    virtual bool less(const JsonValue * other) const = 0;
+    virtual void dump(std::string &out) const = 0;
+    virtual double number_value() const;
+    virtual int int_value() const;
+    virtual bool bool_value() const;
+    virtual const std::string &string_value() const;
+    virtual const Json::array &array_items() const;
+    virtual const Json &operator[](size_t i) const;
+    virtual const Json::object &object_items() const;
+    virtual const Json &operator[](const std::string &key) const;
+    virtual ~JsonValue() {}
+};
+
+} // namespace json11

--- a/src/mmcMain.cpp
+++ b/src/mmcMain.cpp
@@ -1,140 +1,166 @@
 #include "mmchain.h"
 #include "mmc_config.h"
+#include <string.h>
+#include <stdlib.h>
 using namespace std;
 
 void print_usage(){
 	cout << "Usage:" << endl;
-	cout << "mmc input_file initial_output_file_name [options]" << endl;
-	cout << "mmc sets up a composite markov chain sampling process using the provided initial clk file." << endl;
-	cout << "mmc operators:" << endl;
-	cout << "-zmin\tlowest z-value" << endl;
-	cout << "-zmax\thighest z-value" << endl;
-	cout << "-q\tq-value" << endl;
-	cout << "-sr\tlower bound for swap ratio" << endl;
-	cout << "-s\tnumber of BFACF steps between swaps" << endl;
-	cout << "[HALTING CRITERIA] -n\tnumber of samples per chain before completion" << endl;
-	cout << "[HALTING CRITERIA] -t\tInteger number of hours to run before completion" << endl;
-	cout << "-c\tnumber of BFACF steps between samples" << endl;
-	cout << "-m\tinitial number of CMC chains. If m = 1, then z-max will be the z-value" << endl;
-	cout << "-w\tnumber of BFACF steps to take in each chain to warmup" << endl;
-	cout << "-mode\tsample mode: ['a' Analyze Only], ['s' Sample Only], ['b' Analyze and Sample], ['m' Block-Mean Sampling]" << endl;
-	cout << "[OPTIONAL] -minarc\tsample filtering criteria" << endl;
-	cout << "[OPTIONAL] -maxarc\tsample filtering criteria" << endl;
-	cout << "[PREREQ: minarc > 3 and maxarc > minarc] -targetlength\tsample filtering criteria" << endl;
-	cout << "-seed\tset seed for random number generator" << endl;
-	cout << "-bfs\tnumber of conformations to save per binary block file" << endl;
-	cout << "+s\tsupress status output. For use with shell scripts." << endl;
-	cout << "-recomboParas:" << endl;
-	cout << "    is    : do incoherent(knot->knot) and standard recombo" << endl;                   //00
-	cout << "    ip   : do incoherent and positive virtual recombo" << endl;                        //01
-	cout << "    in  : do incoherent and negative virtual recombo" << endl;                         //02
-    cout << "    ia  : do incoherent and automatic virtual recombo" << endl;                        //03
-    cout << "    isp   : " << endl;                                                                 //04
-    cout << "    isn  : " << endl;                                                                  //05
-    cout << "    isa  : " << endl;                                                                  //06
-	cout << "    ds    : do only coherent(knot->link OR link->knot) standard recombo" << endl;      //10
-	cout << "    dp  : do only coherent positive virtual recombo" << endl;                          //11
-	cout << "    dn  : do only coherent negative virtual recombo" << endl;                          //12
-    cout << "    da  : do only coherent automatic virtual recombo" << endl;                         //13
-    cout << "    dsp  : do a mix of coherent standard and positive virtual recombo" << endl;        //14
-    cout << "    dsn  : do a mix of coherent standard and negative virtual recombo" << endl;        //15
-    cout << "    dsa  : do a mix of coherent standard and automatic virtual recombo" << endl;       //16
-	cout << "    ONLY USE is or ds IF KNOT SUBSTRATE IS A LINK!!!!" << endl;
-	cout << "---------------------------------------------------------------------------------------------------------------" << endl;
-	cout << "When selecting values for minarc and maxarc, notice that if the range is too small, " << endl;
-	cout << "it would take long time to run, because the samples that satisfy that minarc and maxarc are rare."<< endl;
+	cout << "  mmc input_file output_file [options]" << endl;
+	cout << "  mmc -config config.json" << endl;
+	cout << endl;
+	cout << "mmc sets up a composite markov chain sampling process using the provided" << endl;
+	cout << "initial clk file. Configuration is specified either via CLI options or a" << endl;
+	cout << "JSON config file, but not both." << endl;
+	cout << endl;
+	cout << "Options:" << endl;
+	cout << "  -config FILE\tload all parameters from JSON config file" << endl;
+	cout << "  -zmin\t\tlowest z-value" << endl;
+	cout << "  -zmax\t\thighest z-value" << endl;
+	cout << "  -q\t\tq-value [default: 1]" << endl;
+	cout << "  -sr\t\tlower bound for swap ratio [default: 0.8]" << endl;
+	cout << "  -s\t\tnumber of BFACF steps between swaps [default: 5]" << endl;
+	cout << "  -n\t\tnumber of samples per chain before completion [HALTING]" << endl;
+	cout << "  -t\t\tinteger number of hours to run before completion [HALTING]" << endl;
+	cout << "  -c\t\tnumber of BFACF steps between samples [default: 20000]" << endl;
+	cout << "  -m\t\tinitial number of CMC chains [default: 1]" << endl;
+	cout << "  -w\t\tnumber of BFACF steps to warmup [default: 100000]" << endl;
+	cout << "  -mode\t\tsample mode: a(nalyze), s(ample), b(oth), m(ean), f(ilter), r(ecombo)" << endl;
+	cout << "  -seed\t\tset seed for RNG [default: system time]" << endl;
+	cout << "  -bfs\t\tconformations per binary block file" << endl;
+	cout << "  -minarc\tmin arclength for reconnection site filtering" << endl;
+	cout << "  -maxarc\tmax arclength for reconnection site filtering" << endl;
+	cout << "  -targetlength\trequired conformation length (requires -minarc > 3)" << endl;
+	cout << "  +s\t\tsuppress status output" << endl;
+	cout << endl;
+	cout << "  -recomboParas CODE   reconnection parameters:" << endl;
+	cout << "    Inverted repeat:  is (standard), ip (positive), in (negative), ia (automatic)" << endl;
+	cout << "    Direct repeat:    ds (standard), dp (positive), dn (negative), da (automatic)" << endl;
+	cout << "    Mixed:            dsp, dsn, dsa, isp, isn, isa" << endl;
+	cout << endl;
+	cout << "At least one halting criterion (-n or -t) is required." << endl;
 }
 
 int main(int argc, char* argv[]){
 	if (argc <= 1){
 		print_usage();
-		exit(0);
+		return 0;
 	}
 
 	MmcConfig config;
-	config.input_file = argv[1];
-	config.output_file = argv[2];
 
-	for (int i = 3; i < argc; i++){
-		if (!strcmp(argv[i], "-zmin")){
-			config.z_min = atof(argv[i + 1]);
-			i++;
+	if (!strcmp(argv[1], "-config")) {
+		// JSON config mode
+		if (argc < 3) {
+			cerr << "Error: -config requires a file path" << endl;
+			return 1;
 		}
-		else if (!strcmp(argv[i], "-recomboParas"))
-		{
-			string paras(argv[i + 1]);
-			if (!config.parse_recombo_paras(paras)) {
-				cerr << "Error: unrecognized -recomboParas value '" << paras << "'" << endl;
+		if (argc > 3) {
+			cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+			return 1;
+		}
+
+		vector<string> json_errors;
+		config = MmcConfig::from_json(argv[2], json_errors);
+		if (!json_errors.empty()) {
+			for (size_t i = 0; i < json_errors.size(); i++)
+				cerr << "Error: " << json_errors[i] << endl;
+			return 1;
+		}
+	} else {
+		// CLI mode
+		if (argc <= 2) {
+			print_usage();
+			return 0;
+		}
+		config.input_file = argv[1];
+		config.output_file = argv[2];
+
+		for (int i = 3; i < argc; i++){
+			if (!strcmp(argv[i], "-config")){
+				cerr << "Error: -config and CLI options are mutually exclusive" << endl;
 				return 1;
 			}
-			i++;
-		}
-		else if (!strcmp(argv[i], "-zmax")){
-			config.z_max = atof(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-q")){
-			config.q = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-sr")){
-			config.swap_ratio = atof(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-s")){
-			config.swap_interval = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-n")){
-			config.num_samples = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-c")){
-			config.steps_between_samples = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-m")){
-			config.num_chains = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-w")){
-			config.warmup_steps = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-mode")){
-			config.sample_mode = *argv[i + 1];
-			i++;
-		}
-		else if (!strcmp(argv[i], "-seed")){
-			config.seed = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-minarc")){
-			config.min_arc = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-maxarc")){
-			config.max_arc = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-targetlength")){
-			config.target_recombo_length = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-bfs")){
-			config.block_file_size = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-t")){
-			config.time_limit_hours = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "+s")){
-			config.suppress_output = true;
-		}
-		else{
-			cerr << "Error: unrecognized option '" << argv[i] << "'" << endl;
-			return 1;
+			else if (!strcmp(argv[i], "-zmin")){
+				config.z_min = atof(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-recomboParas"))
+			{
+				string paras(argv[i + 1]);
+				if (!config.parse_recombo_paras(paras)) {
+					cerr << "Error: unrecognized -recomboParas value '" << paras << "'" << endl;
+					return 1;
+				}
+				i++;
+			}
+			else if (!strcmp(argv[i], "-zmax")){
+				config.z_max = atof(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-q")){
+				config.q = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-sr")){
+				config.swap_ratio = atof(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-s")){
+				config.swap_interval = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-n")){
+				config.num_samples = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-c")){
+				config.steps_between_samples = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-m")){
+				config.num_chains = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-w")){
+				config.warmup_steps = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-mode")){
+				config.sample_mode = *argv[i + 1];
+				i++;
+			}
+			else if (!strcmp(argv[i], "-seed")){
+				config.seed = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-minarc")){
+				config.min_arc = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-maxarc")){
+				config.max_arc = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-targetlength")){
+				config.target_recombo_length = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-bfs")){
+				config.block_file_size = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-t")){
+				config.time_limit_hours = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "+s")){
+				config.suppress_output = true;
+			}
+			else{
+				cerr << "Error: unrecognized option '" << argv[i] << "'" << endl;
+				return 1;
+			}
 		}
 	}
 

--- a/src/mmc_config.cpp
+++ b/src/mmc_config.cpp
@@ -1,4 +1,8 @@
 #include "mmc_config.h"
+#include "json11.hpp"
+#include <fstream>
+#include <sstream>
+#include <iostream>
 
 bool MmcConfig::parse_recombo_paras(const std::string& paras) {
     if (paras.length() < 2 || paras.length() > 3)
@@ -68,4 +72,139 @@ std::vector<std::string> MmcConfig::validate() const {
         errors.push_back("-targetlength requires -minarc > 3");
 
     return errors;
+}
+
+MmcConfig MmcConfig::from_json(const std::string& filepath, std::vector<std::string>& errors) {
+    MmcConfig config;
+
+    std::ifstream file(filepath.c_str());
+    if (!file.is_open()) {
+        errors.push_back("cannot open config file: " + filepath);
+        return config;
+    }
+
+    std::stringstream buf;
+    buf << file.rdbuf();
+    std::string contents = buf.str();
+
+    std::string parse_err;
+    json11::Json json = json11::Json::parse(contents, parse_err);
+    if (!parse_err.empty()) {
+        errors.push_back("JSON parse error: " + parse_err);
+        return config;
+    }
+
+    if (!json.is_object()) {
+        errors.push_back("config file must contain a JSON object");
+        return config;
+    }
+
+    // Key names match stamp_log() output
+    for (auto& kv : json.object_items()) {
+        const std::string& key = kv.first;
+        const json11::Json& val = kv.second;
+
+        if (key == "input_file")
+            config.input_file = val.string_value();
+        else if (key == "output_file")
+            config.output_file = val.string_value();
+        else if (key == "zmin")
+            config.z_min = val.number_value();
+        else if (key == "zmax")
+            config.z_max = val.number_value();
+        else if (key == "q")
+            config.q = val.int_value();
+        else if (key == "target_swap_ratio")
+            config.swap_ratio = val.number_value();
+        else if (key == "swap_interval")
+            config.swap_interval = val.int_value();
+        else if (key == "n_samples")
+            config.num_samples = val.int_value();
+        else if (key == "steps_between_samples")
+            config.steps_between_samples = val.int_value();
+        else if (key == "warmup")
+            config.warmup_steps = val.int_value();
+        else if (key == "initial_n_chains")
+            config.num_chains = val.int_value();
+        else if (key == "sample_mode") {
+            std::string s = val.string_value();
+            if (!s.empty())
+                config.sample_mode = s[0];
+        }
+        else if (key == "seed")
+            config.seed = val.int_value();
+        else if (key == "min_arc")
+            config.min_arc = val.int_value();
+        else if (key == "max_arc")
+            config.max_arc = val.int_value();
+        else if (key == "target_recombo_length")
+            config.target_recombo_length = val.int_value();
+        else if (key == "block_file_size")
+            config.block_file_size = val.int_value();
+        else if (key == "time_limit")
+            config.time_limit_hours = val.int_value();
+        else if (key == "suppress_output")
+            config.suppress_output = val.bool_value();
+        else if (key == "sequence_type") {
+            if (val.is_string()) {
+                std::string s = val.string_value();
+                if (s == "inverted") config.sequence_type = 0;
+                else if (s == "direct") config.sequence_type = 1;
+                else errors.push_back("unknown sequence_type: " + s);
+            } else {
+                config.sequence_type = val.int_value();
+            }
+        }
+        else if (key == "recombo_type") {
+            if (val.is_string()) {
+                std::string s = val.string_value();
+                if (s == "standard")           config.recombo_type = 0;
+                else if (s == "positive")      config.recombo_type = 1;
+                else if (s == "negative")      config.recombo_type = 2;
+                else if (s == "automatic")     config.recombo_type = 3;
+                else if (s == "standard_positive") config.recombo_type = 4;
+                else if (s == "standard_negative") config.recombo_type = 5;
+                else if (s == "standard_automatic") config.recombo_type = 6;
+                else errors.push_back("unknown recombo_type: " + s);
+            } else {
+                config.recombo_type = val.int_value();
+            }
+        }
+        else if (key == "recombo_paras") {
+            if (!config.parse_recombo_paras(val.string_value()))
+                errors.push_back("unrecognized recombo_paras: " + val.string_value());
+        }
+        else {
+            std::cerr << "Warning: unknown config key '" << key << "' (ignored)" << std::endl;
+        }
+    }
+
+    return config;
+}
+
+std::string MmcConfig::to_json() const {
+    json11::Json json = json11::Json::object {
+        {"input_file", input_file},
+        {"output_file", output_file},
+        {"zmin", z_min},
+        {"zmax", z_max},
+        {"q", q},
+        {"target_swap_ratio", swap_ratio},
+        {"swap_interval", swap_interval},
+        {"n_samples", num_samples},
+        {"steps_between_samples", steps_between_samples},
+        {"warmup", (int)warmup_steps},
+        {"initial_n_chains", num_chains},
+        {"sample_mode", std::string(1, sample_mode)},
+        {"seed", seed},
+        {"block_file_size", block_file_size},
+        {"time_limit", time_limit_hours},
+        {"suppress_output", suppress_output},
+        {"min_arc", min_arc},
+        {"max_arc", max_arc},
+        {"target_recombo_length", target_recombo_length},
+        {"sequence_type", sequence_type},
+        {"recombo_type", recombo_type},
+    };
+    return json.dump();
 }

--- a/src/mmc_config.h
+++ b/src/mmc_config.h
@@ -32,4 +32,11 @@ struct MmcConfig {
     // Parse recomboParas string (e.g. "is", "ds", "dsp") into sequence_type and recombo_type.
     // Returns true on success, false if the string is unrecognized.
     bool parse_recombo_paras(const std::string& paras);
+
+    // Load config from a JSON file. Keys match stamp_log() output.
+    // Returns errors via the errors vector; config is partially populated on failure.
+    static MmcConfig from_json(const std::string& filepath, std::vector<std::string>& errors);
+
+    // Serialize config to a JSON string.
+    std::string to_json() const;
 };

--- a/src/zAnalyzerMain.cpp
+++ b/src/zAnalyzerMain.cpp
@@ -1,4 +1,5 @@
 #include "zAnalyzer.h"
+#include "zanalyzer_config.h"
 #include <string.h>
 #include <stdlib.h>
 
@@ -6,80 +7,118 @@ using namespace std;
 
 void print_usage(){
 	cout << "Usage:" << endl;
-	cout << "zAnalyzer input_file [operators/options]" << endl;
-	cout << "zAnalyzer takes an input file of cubic lattice conformations " <<
-		"written in Rob Scharein's CUBE format and outputs a table of average length / Z " <<
-		"value associations with the provided tolerance" << endl << endl;
-	cout << "zAnalyzer operators:" << endl;
-	cout << "-l\ttarget length" << endl;
-	cout << "-tol\ttolerated error in avg length of the returned z-value" << endl;
-	cout << "-zmin\tbest guess for Z value that is a lower bound for the target Z value" << endl;
-	cout << "-zmax\tbest guess for Z value that is an upper bound for the target Z value" << endl;
-	cout << "-c\tbest guess for the number of BFACF steps needed between samples for independence" << endl;
-	cout << "-w\tbest guess for an appropriate warmup" << endl;
-	cout << "-q\tbest guess for an initial q value" << endl;
-	cout << "-s\tset seed to a specific value (default is current system time)" << endl;
+	cout << "  zAnalyzer input_file [options]" << endl;
+	cout << "  zAnalyzer -config config.json" << endl;
+	cout << endl;
+	cout << "zAnalyzer takes an input file of cubic lattice conformations" << endl;
+	cout << "written in Rob Scharein's CUBE format and outputs a table of" << endl;
+	cout << "average length / Z value associations with the provided tolerance." << endl;
+	cout << "Configuration is specified either via CLI options or a JSON config" << endl;
+	cout << "file, but not both." << endl;
+	cout << endl;
+	cout << "Options:" << endl;
+	cout << "  -config FILE\tload all parameters from JSON config file" << endl;
+	cout << "  -l\t\ttarget length" << endl;
+	cout << "  -tol\t\ttolerated error in avg length of the returned z-value" << endl;
+	cout << "  -zmin\t\tlower bound for the target Z value" << endl;
+	cout << "  -zmax\t\tupper bound for the target Z value" << endl;
+	cout << "  -c\t\tBFACF steps between samples" << endl;
+	cout << "  -w\t\twarmup steps" << endl;
+	cout << "  -q\t\tinitial q value" << endl;
+	cout << "  -s\t\tset seed (default is current system time)" << endl;
 }
 
 int main(int argc, char* argv[]){
-	char* infile = NULL;
-	int target_length = 0, tol = 0, warmup = 0, c = 0, q = 0, seed = time(NULL);
-	double z_min = 0, z_max = 0;
-
-	if  (argc < 9){
+	if (argc <= 1){
 		print_usage();
 		return 0;
 	}
 
-	infile = argv[1];
+	ZAnalyzerConfig config;
 
-		for (int i=2; i < argc; i++){
-			if (!strcmp(argv[i], "-l")){
-			target_length = atoi(argv[i+1]);
-			i++;
+	if (!strcmp(argv[1], "-config")) {
+		// JSON config mode
+		if (argc < 3) {
+			cerr << "Error: -config requires a file path" << endl;
+			return 1;
 		}
-		else if (!strcmp(argv[i], "-tol")){
-			tol = atoi(argv[i+1]);
-			i++;
+		if (argc > 3) {
+			cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+			return 1;
 		}
-		else if (!strcmp(argv[i], "-zmax")){
-			z_max = atof(argv[i + 1]);
-			i++;
+
+		vector<string> json_errors;
+		config = ZAnalyzerConfig::from_json(argv[2], json_errors);
+		if (!json_errors.empty()) {
+			for (size_t i = 0; i < json_errors.size(); i++)
+				cerr << "Error: " << json_errors[i] << endl;
+			return 1;
 		}
-		else if (!strcmp(argv[i], "-zmin")){
-			z_min = atof(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-q")){
-			q = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-c")){
-			c = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-w")){
-			warmup = atoi(argv[i + 1]);
-			i++;
-		}
-		else if (!strcmp(argv[i], "-s")){
-			seed = atoi(argv[i + 1]);
-			i++;
-		}
-		else{
-			cout << "unrecognized operator/option. Terminating program...";
-			return 0;
+	} else {
+		// CLI mode
+		config.input_file = argv[1];
+
+		for (int i = 2; i < argc; i++){
+			if (!strcmp(argv[i], "-config")){
+				cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+				return 1;
+			}
+			else if (!strcmp(argv[i], "-l")){
+				config.target_length = atoi(argv[i+1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-tol")){
+				config.tolerance = atoi(argv[i+1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-zmax")){
+				config.z_max = atof(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-zmin")){
+				config.z_min = atof(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-q")){
+				config.q = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-c")){
+				config.steps_between_samples = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-w")){
+				config.warmup = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-s")){
+				config.seed = atoi(argv[i + 1]);
+				i++;
+			}
+			else{
+				cerr << "Error: unrecognized option '" << argv[i] << "'" << endl;
+				return 1;
+			}
 		}
 	}
-		//sanity check
-	if (z_min > z_max){
-		cout << "Error: zmin must be less than zmax." << endl;
-		return 0;
+
+	// Validate
+	vector<string> errors = config.validate();
+	if (!errors.empty()) {
+		for (size_t i = 0; i < errors.size(); i++)
+			cerr << "Error: " << errors[i] << endl;
+		return 1;
 	}
-	
+
+	// Resolve seed
+	int seed = config.seed;
+	if (!seed)
+		seed = time(NULL);
 	srand(seed);
-	Analyzer analyzer(infile, z_min, z_max, warmup, c, q);
-	analyzer.z_from_length(target_length, tol);
-	
+
+	Analyzer analyzer(const_cast<char*>(config.input_file.c_str()),
+		config.z_min, config.z_max, config.warmup, config.steps_between_samples, config.q);
+	analyzer.z_from_length(config.target_length, config.tolerance);
+
 	return 0;
 }

--- a/src/zanalyzer_config.cpp
+++ b/src/zanalyzer_config.cpp
@@ -1,0 +1,70 @@
+#include "zanalyzer_config.h"
+#include "json11.hpp"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+std::vector<std::string> ZAnalyzerConfig::validate() const {
+    std::vector<std::string> errors;
+
+    if (input_file.empty())
+        errors.push_back("input_file is required");
+    if (z_min >= z_max)
+        errors.push_back("zmin must be less than zmax");
+
+    return errors;
+}
+
+ZAnalyzerConfig ZAnalyzerConfig::from_json(const std::string& filepath, std::vector<std::string>& errors) {
+    ZAnalyzerConfig config;
+
+    std::ifstream file(filepath.c_str());
+    if (!file.is_open()) {
+        errors.push_back("cannot open config file: " + filepath);
+        return config;
+    }
+
+    std::stringstream buf;
+    buf << file.rdbuf();
+    std::string contents = buf.str();
+
+    std::string parse_err;
+    json11::Json json = json11::Json::parse(contents, parse_err);
+    if (!parse_err.empty()) {
+        errors.push_back("JSON parse error: " + parse_err);
+        return config;
+    }
+
+    if (!json.is_object()) {
+        errors.push_back("config file must contain a JSON object");
+        return config;
+    }
+
+    for (auto& kv : json.object_items()) {
+        const std::string& key = kv.first;
+        const json11::Json& val = kv.second;
+
+        if (key == "input_file")
+            config.input_file = val.string_value();
+        else if (key == "target_length")
+            config.target_length = val.int_value();
+        else if (key == "tolerance")
+            config.tolerance = val.int_value();
+        else if (key == "zmin")
+            config.z_min = val.number_value();
+        else if (key == "zmax")
+            config.z_max = val.number_value();
+        else if (key == "q")
+            config.q = val.int_value();
+        else if (key == "steps_between_samples")
+            config.steps_between_samples = val.int_value();
+        else if (key == "warmup")
+            config.warmup = val.int_value();
+        else if (key == "seed")
+            config.seed = val.int_value();
+        else
+            std::cerr << "Warning: unknown config key '" << key << "' (ignored)" << std::endl;
+    }
+
+    return config;
+}

--- a/src/zanalyzer_config.h
+++ b/src/zanalyzer_config.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct ZAnalyzerConfig {
+    std::string input_file;
+    int target_length = 0;
+    int tolerance = 0;
+    double z_min = 0.0;
+    double z_max = 0.0;
+    int q = 0;
+    int steps_between_samples = 0;
+    int warmup = 0;
+    int seed = 0;               // 0 = use system time
+
+    std::vector<std::string> validate() const;
+
+    static ZAnalyzerConfig from_json(const std::string& filepath, std::vector<std::string>& errors);
+};


### PR DESCRIPTION
Summary                                                                                                                                      
                                                                                                                                             
  - Add JSON config file support to mmc and zAnalyzer via vendored json11 (Dropbox, MIT, ~1k lines)                                            
  - Both tools accept -config file.json as a mutually exclusive alternative to CLI flags — mixing the two is an error                          
  - mmc JSON keys match stamp_log() output, so users can reference a run's log to write a config                                               
  - recombo_paras, sequence_type, and recombo_type accept human-readable strings in JSON (e.g., "direct", "standard") in addition to numeric   
  values                                                                                                                                     
  - Rewrite help text for both tools: group options, show defaults, document -config                                                           
  - Add ZAnalyzerConfig struct with validation and from_json(), matching the MmcConfig pattern                                               
  - Fix zAnalyzer error handling: unrecognized options now print the offending flag and exit with code 1 (was silent with exit 0)              
                                                                                                                                             
  Test plan                                                                                                                                    
                                                                                                                                               
  - 93/93 unit and regression tests pass                                                                                                       
  - mmc -config file.json produces identical parameters and byte-identical binary output to equivalent CLI invocation                          
  - mmc -config file.json -seed 99 errors: mutually exclusive                                                                                  
  - mmc input output -config file.json errors: mutually exclusive                                                                              
  - Invalid JSON, missing file, and unknown keys handled with clear messages                                                                   
  - zAnalyzer -config / CLI mutual exclusivity works                                                                                           
  - zAnalyzer validation catches zmin >= zmax                                                                                                  
  - Note: zAnalyzer has a pre-existing issue where the user-provided seed never reaches the BFACF engine — tracked separately