### PR TITLE
fix: zAnalyzer rng initialization and seed handling

### DIFF
--- a/src/zAnalyzer.cpp
+++ b/src/zAnalyzer.cpp
@@ -1,7 +1,8 @@
 #include "zAnalyzer.h"
 
-Analyzer::Analyzer(char* filename, double Init_lower, double Init_upper, int warmup, int C_steps, int Q){
+Analyzer::Analyzer(char* filename, double Init_lower, double Init_upper, int warmup, int C_steps, int Q, int seed){
 	add_initial_conformation_from_file(filename);
+	knot->setSeed(seed);
 	init_lower = Init_lower;
 	init_upper = Init_upper;
 	w = warmup;

--- a/src/zAnalyzer.h
+++ b/src/zAnalyzer.h
@@ -48,5 +48,5 @@ public:
 	bool write_table(ofstream);
 	//void read_from_file(ifstream&);
 
-	Analyzer(char* filename, double Init_lower, double Init_upper, int warmup, int c, int init_q);
+	Analyzer(char* filename, double Init_lower, double Init_upper, int warmup, int c, int init_q, int seed);
 };

--- a/src/zAnalyzerMain.cpp
+++ b/src/zAnalyzerMain.cpp
@@ -116,8 +116,10 @@ int main(int argc, char* argv[]){
 		seed = time(NULL);
 	srand(seed);
 
+	cout << "seed= " << seed << endl;
+
 	Analyzer analyzer(const_cast<char*>(config.input_file.c_str()),
-		config.z_min, config.z_max, config.warmup, config.steps_between_samples, config.q);
+		config.z_min, config.z_max, config.warmup, config.steps_between_samples, config.q, seed);
 	analyzer.z_from_length(config.target_length, config.tolerance);
 
 	return 0;


### PR DESCRIPTION
 Summary                                                                                                                                      
                                                                                                                                             
  - Fix zAnalyzer seed propagation so the BFACF engine uses the user-specified seed
  - Previously, the -s seed only called srand() (C standard library RNG) but never reached clkConformationBfacf3::setSeed() — the Park-Miller
  RNG that the BFACF engine actually uses was always seeded from the system timer independently                                                
  - Add seed parameter to Analyzer constructor, which calls knot->setSeed(seed) after the BFACF3 object is created
  - Log the resolved seed to stdout so runs are reproducible — zAnalyzer previously had no seed logging at all                                 
                                                                                                                                               
  Test plan                                                                  
                                                                                                                                               
  - 93/93 unit and regression tests pass                                                                                                     
  - Build succeeds on macOS (AppleClang)                                                                                                       
  - Verify two runs with the same -s value produce identical output