### PR TITLE
feat: bfacf cli with json config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ FetchContent_MakeAvailable(googletest)
 
 # Core library shared by all executables and tests
 add_library(recombo_core STATIC
+        src/bfacf_config.cpp
         src/autocorr.cpp
         src/bfacfProbabilities.cpp
         src/bfacfProbabilitiesFromZ.cpp
@@ -53,6 +54,9 @@ target_link_libraries(zAnalyzer recombo_core)
 
 add_executable(mmc src/mmcMain.cpp)
 target_link_libraries(mmc recombo_core)
+
+add_executable(bfacf src/bfacfMain.cpp)
+target_link_libraries(bfacf recombo_core)
 
 add_executable(homfly src/homfly1_21.c src/cross.c)
 target_link_libraries(homfly recombo_core)

--- a/src/bfacfMain.cpp
+++ b/src/bfacfMain.cpp
@@ -1,0 +1,251 @@
+#include "bfacf_config.h"
+#include "clkConformationAsList.h"
+#include "clkConformationBfacf3.h"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+using namespace std;
+
+void print_usage(){
+	cout << "Usage:" << endl;
+	cout << "  bfacf input_file output_file [options]" << endl;
+	cout << "  bfacf -config config.json" << endl;
+	cout << endl;
+	cout << "Run BFACF steps on a cubic lattice conformation (knot or 2-component link)." << endl;
+	cout << "Configuration is specified either via CLI options or a JSON config file," << endl;
+	cout << "but not both." << endl;
+	cout << endl;
+	cout << "Options:" << endl;
+	cout << "  -config FILE\tload all parameters from JSON config file" << endl;
+	cout << "  -z\t\tfugacity parameter (required)" << endl;
+	cout << "  -q\t\tq value for stepQ [default: 1]" << endl;
+	cout << "  -n\t\tnumber of BFACF steps to perform (required)" << endl;
+	cout << "  -k\t\tsave conformation every k steps [default: save only final]" << endl;
+	cout << "  -bfs\t\tconformations per output file [default: all in one file]" << endl;
+	cout << "  -seed\t\tRNG seed [default: system time]" << endl;
+	cout << "  -fmt\t\toutput format: cube, text, newsud [default: cube]" << endl;
+	cout << "  +s\t\tsuppress progress output" << endl;
+}
+
+void write_conformation(clkConformationBfacf3& knot, int n_components,
+	ostream& out, const string& format) {
+	if (format == "cube") {
+		clkConformationAsList comp0(knot.getComponent(0));
+		comp0.writeAsCube(out);
+		if (n_components == 2) {
+			clkConformationAsList comp1(knot.getComponent(1));
+			comp1.writeAsCube(out);
+		}
+	} else if (format == "text") {
+		clkConformationAsList comp0(knot.getComponent(0));
+		comp0.writeAsText(out);
+		if (n_components == 2) {
+			clkConformationAsList comp1(knot.getComponent(1));
+			comp1.writeAsText(out);
+		}
+	} else if (format == "newsud") {
+		out << knot.writeAsNewsud(0) << endl;
+		if (n_components == 2)
+			out << knot.writeAsNewsud(1) << endl;
+	}
+}
+
+int main(int argc, char* argv[]){
+	if (argc <= 1){
+		print_usage();
+		return 0;
+	}
+
+	BfacfConfig config;
+
+	if (!strcmp(argv[1], "-config")) {
+		if (argc < 3) {
+			cerr << "Error: -config requires a file path" << endl;
+			return 1;
+		}
+		if (argc > 3) {
+			cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+			return 1;
+		}
+
+		vector<string> json_errors;
+		config = BfacfConfig::from_json(argv[2], json_errors);
+		if (!json_errors.empty()) {
+			for (size_t i = 0; i < json_errors.size(); i++)
+				cerr << "Error: " << json_errors[i] << endl;
+			return 1;
+		}
+	} else {
+		if (argc <= 2) {
+			print_usage();
+			return 0;
+		}
+		config.input_file = argv[1];
+		config.output_file = argv[2];
+
+		for (int i = 3; i < argc; i++){
+			if (!strcmp(argv[i], "-config")){
+				cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+				return 1;
+			}
+			else if (!strcmp(argv[i], "-z")){
+				config.z = atof(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-q")){
+				config.q = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-n")){
+				config.steps = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-k")){
+				config.save_interval = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-bfs")){
+				config.block_file_size = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-seed")){
+				config.seed = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-fmt")){
+				config.output_format = argv[i + 1];
+				i++;
+			}
+			else if (!strcmp(argv[i], "+s")){
+				config.suppress_output = true;
+			}
+			else{
+				cerr << "Error: unrecognized option '" << argv[i] << "'" << endl;
+				return 1;
+			}
+		}
+	}
+
+	// Validate
+	vector<string> errors = config.validate();
+	if (!errors.empty()) {
+		for (size_t i = 0; i < errors.size(); i++)
+			cerr << "Error: " << errors[i] << endl;
+		return 1;
+	}
+
+	// Resolve seed
+	int seed = config.seed;
+	if (!seed)
+		seed = time(NULL);
+	srand(seed);
+
+	// Load initial conformation
+	clkConformationAsList comp0, comp1;
+	int n_components = 0;
+
+	ifstream infile(config.input_file.c_str());
+	if (!infile) {
+		cerr << "Error: cannot open input file: " << config.input_file << endl;
+		return 1;
+	}
+	if (!comp0.readFromCoords(infile)) {
+		cerr << "Error: failed to read conformation from: " << config.input_file << endl;
+		return 1;
+	}
+	n_components = 1;
+	if (comp1.readFromCoords(infile))
+		n_components = 2;
+	infile.close();
+
+	// Create BFACF3 engine
+	clkConformationBfacf3* knot;
+	if (n_components == 2)
+		knot = new clkConformationBfacf3(comp0, comp1);
+	else
+		knot = new clkConformationBfacf3(comp0);
+
+	knot->setSeed(seed);
+	knot->setZ(config.z);
+
+	// Log config
+	cout << "input_file= " << config.input_file << endl;
+	cout << "output_file= " << config.output_file << endl;
+	cout << "n_components= " << n_components << endl;
+	cout << "z= " << config.z << endl;
+	cout << "q= " << config.q << endl;
+	cout << "steps= " << config.steps << endl;
+	cout << "save_interval= " << config.save_interval << endl;
+	cout << "seed= " << seed << endl;
+	cout << "output_format= " << config.output_format << endl;
+	cout << endl;
+
+	// Determine output mode
+	bool binary_output = (config.output_format == "cube");
+	int save_interval = config.save_interval > 0 ? config.save_interval : config.steps;
+	int block_file_size = config.block_file_size;
+
+	// Output file management
+	ofstream out;
+	int file_number = 0;
+	int conformations_in_file = 0;
+	int total_saved = 0;
+
+	auto open_next_file = [&]() {
+		if (out.is_open())
+			out.close();
+		file_number++;
+		stringstream ss;
+		ss << config.output_file << "n" << file_number;
+		if (binary_output)
+			ss << ".b";
+		else
+			ss << ".txt";
+
+		ios_base::openmode mode = ios::out;
+		if (binary_output)
+			mode |= ios::binary;
+		out.open(ss.str().c_str(), mode);
+
+		if (!out) {
+			cerr << "Error: cannot open output file: " << ss.str() << endl;
+			exit(1);
+		}
+		conformations_in_file = 0;
+	};
+
+	open_next_file();
+
+	// Run BFACF steps
+	for (int step = 1; step <= config.steps; step++) {
+		knot->stepQ(1, config.q, config.z);
+
+		if (step % save_interval == 0) {
+			// Check if we need a new block file
+			if (block_file_size > 0 && conformations_in_file >= block_file_size)
+				open_next_file();
+
+			write_conformation(*knot, n_components, out, config.output_format);
+			conformations_in_file++;
+			total_saved++;
+
+			if (!config.suppress_output)
+				cout << "step " << step << " / " << config.steps
+					<< "  length=" << knot->getComponent(0).size()
+					<< "  saved=" << total_saved << endl;
+		}
+	}
+
+	out.close();
+
+	if (!config.suppress_output)
+		cout << endl << "Done. " << total_saved << " conformation(s) saved." << endl;
+
+	delete knot;
+	return 0;
+}

--- a/src/bfacf_config.cpp
+++ b/src/bfacf_config.cpp
@@ -1,0 +1,82 @@
+#include "bfacf_config.h"
+#include "json11.hpp"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+std::vector<std::string> BfacfConfig::validate() const {
+    std::vector<std::string> errors;
+
+    if (input_file.empty())
+        errors.push_back("input_file is required");
+    if (output_file.empty())
+        errors.push_back("output_file is required");
+    if (z <= 0.0)
+        errors.push_back("z must be > 0");
+    if (steps <= 0)
+        errors.push_back("steps (-n) must be > 0");
+    if (save_interval < 0)
+        errors.push_back("save_interval (-k) must be >= 0");
+    if (save_interval > steps)
+        errors.push_back("save_interval (-k) must be <= steps (-n)");
+    if (output_format != "cube" && output_format != "text" && output_format != "newsud")
+        errors.push_back("output_format (-fmt) must be one of: cube, text, newsud");
+
+    return errors;
+}
+
+BfacfConfig BfacfConfig::from_json(const std::string& filepath, std::vector<std::string>& errors) {
+    BfacfConfig config;
+
+    std::ifstream file(filepath.c_str());
+    if (!file.is_open()) {
+        errors.push_back("cannot open config file: " + filepath);
+        return config;
+    }
+
+    std::stringstream buf;
+    buf << file.rdbuf();
+    std::string contents = buf.str();
+
+    std::string parse_err;
+    json11::Json json = json11::Json::parse(contents, parse_err);
+    if (!parse_err.empty()) {
+        errors.push_back("JSON parse error: " + parse_err);
+        return config;
+    }
+
+    if (!json.is_object()) {
+        errors.push_back("config file must contain a JSON object");
+        return config;
+    }
+
+    for (auto& kv : json.object_items()) {
+        const std::string& key = kv.first;
+        const json11::Json& val = kv.second;
+
+        if (key == "input_file")
+            config.input_file = val.string_value();
+        else if (key == "output_file")
+            config.output_file = val.string_value();
+        else if (key == "z")
+            config.z = val.number_value();
+        else if (key == "q")
+            config.q = val.int_value();
+        else if (key == "steps")
+            config.steps = val.int_value();
+        else if (key == "save_interval")
+            config.save_interval = val.int_value();
+        else if (key == "block_file_size")
+            config.block_file_size = val.int_value();
+        else if (key == "seed")
+            config.seed = val.int_value();
+        else if (key == "output_format")
+            config.output_format = val.string_value();
+        else if (key == "suppress_output")
+            config.suppress_output = val.bool_value();
+        else
+            std::cerr << "Warning: unknown config key '" << key << "' (ignored)" << std::endl;
+    }
+
+    return config;
+}

--- a/src/bfacf_config.h
+++ b/src/bfacf_config.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct BfacfConfig {
+    std::string input_file;
+    std::string output_file;
+    double z = 0.0;
+    int q = 1;
+    int steps = 0;
+    int save_interval = 0;      // save every k steps; 0 = save only final
+    int block_file_size = 0;    // conformations per .b file; 0 = all in one file
+    int seed = 0;               // 0 = use system time
+    std::string output_format = "cube";  // "cube", "text", "newsud"
+    bool suppress_output = false;
+
+    std::vector<std::string> validate() const;
+
+    static BfacfConfig from_json(const std::string& filepath, std::vector<std::string>& errors);
+};


### PR DESCRIPTION
Summary                                                                                                                                      
                                                                                                                                               
  - Add standalone bfacf executable that exposes the BFACF stepping engine directly, without the MMC calibration/sampling/swap machinery       
  - Takes a conformation file (knot or 2-component link), runs a specified number of BFACF steps, and writes output conformations              
  - Supports saving snapshots every k steps (-k) with optional block file splitting (-bfs)                                                     
  - Three output formats: cube (binary), text (coordinates), newsud (direction string)                                                         
  - JSON config support via -config, mutually exclusive with CLI flags, same pattern as mmc and zAnalyzer                                      
  - Seed is resolved, logged, and passed to the BFACF engine for full reproducibility                                                          
                                                                                                                                               
  Test plan                                                                                                                                    
                                                                                                                                               
  - 93/93 existing tests pass (no regressions)                                                                                                 
  - 1-component knot: runs 1000 steps, saves every 500, produces 2 conformations                                                             
  - 2-component link: both components evolve under BFACF (verified initial 8+8 vertices grew to 20+14 after 10,000 steps)                      
  - Reproducibility: same seed produces byte-identical binary output                                                                           
  - JSON config produces identical output to equivalent CLI invocation                                                                         
  - Output formats: cube, text, newsud all produce valid output                                                                                
  - Validation: missing -z, missing -n, mutual exclusivity all produce clear errors