### PR TITLE
feat: recombo cli w/ json config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(recombo_core STATIC
         src/polynomesAZ.c
         src/writhe.cpp
         src/pseudorandom.cpp
+        src/recombo_config.cpp
         src/regularNgon.cpp
         src/zAnalyzer.cpp
         src/zanalyzer_config.cpp)
@@ -57,6 +58,9 @@ target_link_libraries(mmc recombo_core)
 
 add_executable(bfacf src/bfacfMain.cpp)
 target_link_libraries(bfacf recombo_core)
+
+add_executable(recombo src/recomboMain.cpp)
+target_link_libraries(recombo recombo_core)
 
 add_executable(homfly src/homfly1_21.c src/cross.c)
 target_link_libraries(homfly recombo_core)

--- a/src/recomboMain.cpp
+++ b/src/recomboMain.cpp
@@ -1,0 +1,305 @@
+#include "recombo_config.h"
+#include "clkConformationAsList.h"
+#include "clkConformationBfacf3.h"
+#include "pseudorandom.h"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <list>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+using namespace std;
+
+void print_usage(){
+	cout << "Usage:" << endl;
+	cout << "  recombo input_file output_file [options]" << endl;
+	cout << "  recombo -config config.json" << endl;
+	cout << endl;
+	cout << "Perform topological reconnection on a cubic lattice conformation" << endl;
+	cout << "(knot or 2-component link). Finds reconnection sites matching arc" << endl;
+	cout << "length criteria and performs reconnection at a randomly chosen site." << endl;
+	cout << "Configuration is specified either via CLI options or a JSON config" << endl;
+	cout << "file, but not both." << endl;
+	cout << endl;
+	cout << "Options:" << endl;
+	cout << "  -config FILE\tload all parameters from JSON config file" << endl;
+	cout << "  -minarc\tminimum arc length (required)" << endl;
+	cout << "  -maxarc\tmaximum arc length (required)" << endl;
+	cout << "  -targetlength\tonly reconnect if conformation has this length" << endl;
+	cout << "  -seed\t\tRNG seed [default: system time]" << endl;
+	cout << "  -fmt\t\toutput format: cube, text, newsud [default: cube]" << endl;
+	cout << "  +s\t\tsuppress progress output" << endl;
+	cout << endl;
+	cout << "  -recomboParas CODE   reconnection parameters (required):" << endl;
+	cout << "    Inverted repeat:  is (standard), ip (positive), in (negative), ia (automatic)" << endl;
+	cout << "    Direct repeat:    ds (standard), dp (positive), dn (negative), da (automatic)" << endl;
+	cout << "    Mixed:            dsp, dsn, dsa, isp, isn, isa" << endl;
+}
+
+void write_conformation(clkConformationBfacf3& knot, int n_components,
+	ostream& out, const string& format) {
+	if (format == "cube") {
+		clkConformationAsList comp0(knot.getComponent(0));
+		comp0.writeAsCube(out);
+		if (n_components == 2) {
+			clkConformationAsList comp1(knot.getComponent(1));
+			comp1.writeAsCube(out);
+		}
+	} else if (format == "text") {
+		clkConformationAsList comp0(knot.getComponent(0));
+		comp0.writeAsText(out);
+		if (n_components == 2) {
+			clkConformationAsList comp1(knot.getComponent(1));
+			comp1.writeAsText(out);
+		}
+	} else if (format == "newsud") {
+		out << knot.writeAsNewsud(0) << endl;
+		if (n_components == 2)
+			out << knot.writeAsNewsud(1) << endl;
+	}
+}
+
+void write_sites(clkConformationBfacf3& knot, int site_choice, int n_components,
+	ostream& out) {
+	vector<threevector<int> > sitelist = knot.getChosenSite(site_choice);
+	clkConformationAsList sites;
+
+	if ((knot.dirIsParal(site_choice) && n_components == 1) ||
+		(knot.dirIsParal(site_choice) && n_components == 2)) {
+		sites.addVertexBack(sitelist[0]);
+		sites.addVertexBack(sitelist[1]);
+		sites.addVertexBack(sitelist[3]);
+		sites.addVertexBack(sitelist[2]);
+	} else {
+		for (int j = 0; j < 4; ++j)
+			sites.addVertexBack(sitelist[j]);
+	}
+
+	sites.writeAsCube(out);
+}
+
+int main(int argc, char* argv[]){
+	if (argc <= 1){
+		print_usage();
+		return 0;
+	}
+
+	RecomboConfig config;
+
+	if (!strcmp(argv[1], "-config")) {
+		if (argc < 3) {
+			cerr << "Error: -config requires a file path" << endl;
+			return 1;
+		}
+		if (argc > 3) {
+			cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+			return 1;
+		}
+
+		vector<string> json_errors;
+		config = RecomboConfig::from_json(argv[2], json_errors);
+		if (!json_errors.empty()) {
+			for (size_t i = 0; i < json_errors.size(); i++)
+				cerr << "Error: " << json_errors[i] << endl;
+			return 1;
+		}
+	} else {
+		if (argc <= 2) {
+			print_usage();
+			return 0;
+		}
+		config.input_file = argv[1];
+		config.output_file = argv[2];
+
+		for (int i = 3; i < argc; i++){
+			if (!strcmp(argv[i], "-config")){
+				cerr << "Error: -config and CLI options are mutually exclusive" << endl;
+				return 1;
+			}
+			else if (!strcmp(argv[i], "-minarc")){
+				config.min_arc = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-maxarc")){
+				config.max_arc = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-targetlength")){
+				config.target_length = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-recomboParas")){
+				string paras(argv[i + 1]);
+				if (!config.parse_recombo_paras(paras)) {
+					cerr << "Error: unrecognized -recomboParas value '" << paras << "'" << endl;
+					return 1;
+				}
+				i++;
+			}
+			else if (!strcmp(argv[i], "-seed")){
+				config.seed = atoi(argv[i + 1]);
+				i++;
+			}
+			else if (!strcmp(argv[i], "-fmt")){
+				config.output_format = argv[i + 1];
+				i++;
+			}
+			else if (!strcmp(argv[i], "+s")){
+				config.suppress_output = true;
+			}
+			else{
+				cerr << "Error: unrecognized option '" << argv[i] << "'" << endl;
+				return 1;
+			}
+		}
+	}
+
+	// Validate
+	vector<string> errors = config.validate();
+	if (!errors.empty()) {
+		for (size_t i = 0; i < errors.size(); i++)
+			cerr << "Error: " << errors[i] << endl;
+		return 1;
+	}
+
+	// Resolve seed
+	int seed = config.seed;
+	if (!seed)
+		seed = time(NULL);
+	srand(seed);
+
+	// Load initial conformation
+	clkConformationAsList comp0, comp1;
+	int n_components = 0;
+
+	ifstream infile(config.input_file.c_str());
+	if (!infile) {
+		cerr << "Error: cannot open input file: " << config.input_file << endl;
+		return 1;
+	}
+	if (!comp0.readFromCoords(infile)) {
+		cerr << "Error: failed to read conformation from: " << config.input_file << endl;
+		return 1;
+	}
+	n_components = 1;
+	if (comp1.readFromCoords(infile))
+		n_components = 2;
+	infile.close();
+
+	// Create BFACF3 engine (needed for recombo site detection)
+	clkConformationBfacf3* knot;
+	if (n_components == 2)
+		knot = new clkConformationBfacf3(comp0, comp1);
+	else
+		knot = new clkConformationBfacf3(comp0);
+
+	knot->setSeed(seed);
+
+	// Check target length constraint
+	if (config.target_length > 0) {
+		int length = knot->getComponent(0).size();
+		if (n_components == 2)
+			length += knot->getComponent(1).size();
+		if (length != config.target_length) {
+			cerr << "Error: conformation length " << length
+				<< " does not match target length " << config.target_length << endl;
+			delete knot;
+			return 1;
+		}
+	}
+
+	// Log config
+	cout << "input_file= " << config.input_file << endl;
+	cout << "output_file= " << config.output_file << endl;
+	cout << "n_components= " << n_components << endl;
+	cout << "min_arc= " << config.min_arc << endl;
+	cout << "max_arc= " << config.max_arc << endl;
+	cout << "sequence_type= " << config.sequence_type << endl;
+	cout << "recombo_type= " << config.recombo_type << endl;
+	cout << "seed= " << seed << endl;
+	cout << "output_format= " << config.output_format << endl;
+	int length = knot->getComponent(0).size();
+	if (n_components == 2)
+		length += knot->getComponent(1).size();
+	cout << "conformation_length= " << length << endl;
+	cout << endl;
+
+	// Find reconnection sites
+	int total_para = 0, total_anti = 0, para = 0, anti = 0;
+	int sites = knot->countRecomboSites(config.min_arc, config.max_arc,
+		config.sequence_type, config.recombo_type,
+		total_para, total_anti, para, anti);
+
+	cout << "sites_found= " << sites << endl;
+	cout << "parallel_sites= " << para << endl;
+	cout << "anti_parallel_sites= " << anti << endl;
+
+	if (sites == 0) {
+		cout << "No reconnection sites found. No output written." << endl;
+		delete knot;
+		return 0;
+	}
+
+	// Choose a site randomly
+	pseudorandom rng(seed);
+	int choice = rng.rand_integer(0, sites);
+	cout << "chosen_site= " << choice << endl;
+	cout << endl;
+
+	// Open output files
+	bool binary = (config.output_format == "cube");
+	string ext = binary ? ".b" : ".txt";
+	ios_base::openmode mode = ios::out;
+	if (binary)
+		mode |= ios::binary;
+
+	string before_path = config.output_file + "_before" + ext;
+	string after_path = config.output_file + "_after" + ext;
+	string sites_path = config.output_file + "_sites.b";
+
+	ofstream before_file(before_path.c_str(), mode);
+	if (!before_file) {
+		cerr << "Error: cannot open output file: " << before_path << endl;
+		delete knot;
+		return 1;
+	}
+
+	ofstream after_file(after_path.c_str(), mode);
+	if (!after_file) {
+		cerr << "Error: cannot open output file: " << after_path << endl;
+		delete knot;
+		return 1;
+	}
+
+	ofstream sites_file(sites_path.c_str(), ios::out | ios::binary);
+	if (!sites_file) {
+		cerr << "Error: cannot open output file: " << sites_path << endl;
+		delete knot;
+		return 1;
+	}
+
+	// Write before conformation
+	write_conformation(*knot, n_components, before_file, config.output_format);
+	before_file.close();
+
+	// Write sites
+	write_sites(*knot, choice, n_components, sites_file);
+	sites_file.close();
+
+	// Perform reconnection
+	if (knot->performRecombination(cout, config.sequence_type, config.recombo_type, n_components, choice)) {
+		// Write after conformation
+		write_conformation(*knot, n_components, after_file, config.output_format);
+		if (!config.suppress_output)
+			cout << "Reconnection performed successfully." << endl;
+	} else {
+		cerr << "Warning: reconnection failed at chosen site." << endl;
+	}
+
+	after_file.close();
+	delete knot;
+	return 0;
+}

--- a/src/recombo_config.cpp
+++ b/src/recombo_config.cpp
@@ -1,0 +1,139 @@
+#include "recombo_config.h"
+#include "json11.hpp"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+bool RecomboConfig::parse_recombo_paras(const std::string& paras) {
+    if (paras.length() < 2 || paras.length() > 3)
+        return false;
+
+    char prefix = paras[0];
+    if (prefix == 'i')
+        sequence_type = 0;
+    else if (prefix == 'd')
+        sequence_type = 1;
+    else
+        return false;
+
+    if (paras.length() == 2) {
+        char code = paras[1];
+        if (code == 's')      recombo_type = 0;
+        else if (code == 'p') recombo_type = 1;
+        else if (code == 'n') recombo_type = 2;
+        else if (code == 'a') recombo_type = 3;
+        else return false;
+    } else {
+        if (paras[1] != 's')
+            return false;
+        char code = paras[2];
+        if (code == 'p')      recombo_type = 4;
+        else if (code == 'n') recombo_type = 5;
+        else if (code == 'a') recombo_type = 6;
+        else return false;
+    }
+    return true;
+}
+
+std::vector<std::string> RecomboConfig::validate() const {
+    std::vector<std::string> errors;
+
+    if (input_file.empty())
+        errors.push_back("input_file is required");
+    if (output_file.empty())
+        errors.push_back("output_file is required");
+    if (min_arc <= 0)
+        errors.push_back("-minarc must be > 0");
+    if (max_arc <= 0)
+        errors.push_back("-maxarc must be > 0");
+    if (min_arc >= max_arc)
+        errors.push_back("-minarc must be less than -maxarc");
+    if (sequence_type == -1 || recombo_type == -1)
+        errors.push_back("-recomboParas is required");
+    if (output_format != "cube" && output_format != "text" && output_format != "newsud")
+        errors.push_back("-fmt must be one of: cube, text, newsud");
+
+    return errors;
+}
+
+RecomboConfig RecomboConfig::from_json(const std::string& filepath, std::vector<std::string>& errors) {
+    RecomboConfig config;
+
+    std::ifstream file(filepath.c_str());
+    if (!file.is_open()) {
+        errors.push_back("cannot open config file: " + filepath);
+        return config;
+    }
+
+    std::stringstream buf;
+    buf << file.rdbuf();
+    std::string contents = buf.str();
+
+    std::string parse_err;
+    json11::Json json = json11::Json::parse(contents, parse_err);
+    if (!parse_err.empty()) {
+        errors.push_back("JSON parse error: " + parse_err);
+        return config;
+    }
+
+    if (!json.is_object()) {
+        errors.push_back("config file must contain a JSON object");
+        return config;
+    }
+
+    for (auto& kv : json.object_items()) {
+        const std::string& key = kv.first;
+        const json11::Json& val = kv.second;
+
+        if (key == "input_file")
+            config.input_file = val.string_value();
+        else if (key == "output_file")
+            config.output_file = val.string_value();
+        else if (key == "min_arc")
+            config.min_arc = val.int_value();
+        else if (key == "max_arc")
+            config.max_arc = val.int_value();
+        else if (key == "target_length")
+            config.target_length = val.int_value();
+        else if (key == "seed")
+            config.seed = val.int_value();
+        else if (key == "output_format")
+            config.output_format = val.string_value();
+        else if (key == "suppress_output")
+            config.suppress_output = val.bool_value();
+        else if (key == "recombo_paras") {
+            if (!config.parse_recombo_paras(val.string_value()))
+                errors.push_back("unrecognized recombo_paras: " + val.string_value());
+        }
+        else if (key == "sequence_type") {
+            if (val.is_string()) {
+                std::string s = val.string_value();
+                if (s == "inverted") config.sequence_type = 0;
+                else if (s == "direct") config.sequence_type = 1;
+                else errors.push_back("unknown sequence_type: " + s);
+            } else {
+                config.sequence_type = val.int_value();
+            }
+        }
+        else if (key == "recombo_type") {
+            if (val.is_string()) {
+                std::string s = val.string_value();
+                if (s == "standard")           config.recombo_type = 0;
+                else if (s == "positive")      config.recombo_type = 1;
+                else if (s == "negative")      config.recombo_type = 2;
+                else if (s == "automatic")     config.recombo_type = 3;
+                else if (s == "standard_positive") config.recombo_type = 4;
+                else if (s == "standard_negative") config.recombo_type = 5;
+                else if (s == "standard_automatic") config.recombo_type = 6;
+                else errors.push_back("unknown recombo_type: " + s);
+            } else {
+                config.recombo_type = val.int_value();
+            }
+        }
+        else {
+            std::cerr << "Warning: unknown config key '" << key << "' (ignored)" << std::endl;
+        }
+    }
+
+    return config;
+}

--- a/src/recombo_config.h
+++ b/src/recombo_config.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct RecomboConfig {
+    std::string input_file;
+    std::string output_file;
+    int min_arc = 0;
+    int max_arc = 0;
+    int target_length = 0;      // 0 = no length constraint
+    int sequence_type = -1;     // -1 = unset, 0 = inverted, 1 = direct
+    int recombo_type = -1;      // -1 = unset, 0-6
+    int seed = 0;               // 0 = use system time
+    std::string output_format = "cube";  // "cube", "text", "newsud"
+    bool suppress_output = false;
+
+    std::vector<std::string> validate() const;
+    bool parse_recombo_paras(const std::string& paras);
+
+    static RecomboConfig from_json(const std::string& filepath, std::vector<std::string>& errors);
+};


### PR DESCRIPTION
Summary                                                                                                                                      
                                                                                                                                               
  - Add standalone recombo executable that performs topological reconnection on a cubic lattice conformation without the MMC sampling machinery
  - Takes a conformation (knot or 2-component link), finds reconnection sites matching arc length criteria, performs reconnection at a randomly
   chosen site, and writes before/after/sites output files                                                                                     
  - Supports all existing reconnection modes via -recomboParas (inverted/direct repeat, standard/positive/negative/automatic, and mixed modes)
  - Optional -targetlength constraint rejects conformations that don't match the specified length                                              
  - Three output formats: cube (binary), text (coordinates), newsud (direction string)                                                         
  - JSON config support via -config, mutually exclusive with CLI flags       
  - Outputs <name>_before.{b,txt}, <name>_after.{b,txt}, and <name>_sites.b                                                                    
  - Enables a bfacf → recombo pipeline: grow a conformation to sufficient length with bfacf, then perform reconnection with recombo, without 
  needing the full mmc simulation driver                                                                                                       
                                                                                                                                             
  Test plan                                                                                                                                    
                                                                                                                                             
  - 93/93 existing tests pass                                                                                                                  
  - 1-component knot: reconnection on 3_1 trefoil finds 1 anti-parallel site and reconnects                                                    
  - 2-component link: grew Hopf link with bfacf (200k steps), fed to recombo, found 1 parallel site and reconnected — confirms the bfacf →     
  recombo pipeline                                                                                                                             
  - No-sites case: small initial conformations correctly report 0 sites and exit cleanly                                                       
  - JSON config produces identical output to equivalent CLI invocation (same seed, same before/after files)                                    
  - Validation: missing -minarc, -maxarc, -recomboParas all produce clear errors                                                               
  - -targetlength constraint rejects non-matching conformations