### PR TITLE
Test BFACF with q=2 and q=3

### DIFF
--- a/test/data/bfacf_stepq_cases.json
+++ b/test/data/bfacf_stepq_cases.json
@@ -1,0 +1,103 @@
+{
+  "cases": [
+    {
+      "name": "trefoil_q1_seed1",
+      "knot_type": "3_1",
+      "source_file": "initial/3_1",
+      "component_count": 1,
+      "seed": 1,
+      "z": 0.198787988281,
+      "q": 1,
+      "steps": 300,
+      "expected_newsud": ["enueussedwdndenwneuuwnwswwseseeedsswwnwn"]
+    },
+    {
+      "name": "trefoil_q2_seed1",
+      "knot_type": "3_1",
+      "source_file": "initial/3_1",
+      "component_count": 1,
+      "seed": 1,
+      "z": 0.198787988281,
+      "q": 2,
+      "steps": 300,
+      "expected_newsud": ["enueussedwdndenwneuuwnwswwseseeendssswwnwn"]
+    },
+    {
+      "name": "trefoil_q3_seed1",
+      "knot_type": "3_1",
+      "source_file": "initial/3_1",
+      "component_count": 1,
+      "seed": 1,
+      "z": 0.198787988281,
+      "q": 3,
+      "steps": 300,
+      "expected_newsud": ["ueuussddendnwnwuusseeesswwwnwswdneednn"]
+    },
+    {
+      "name": "figure8_q1_seed1",
+      "knot_type": "4_1",
+      "source_file": "initial/4_1",
+      "component_count": 1,
+      "seed": 1,
+      "z": 0.18762490234400001,
+      "q": 1,
+      "steps": 300,
+      "expected_newsud": ["eusuuuwswdddnennwuuessseednnwwwdde"]
+    },
+    {
+      "name": "figure8_q2_seed1",
+      "knot_type": "4_1",
+      "source_file": "initial/4_1",
+      "component_count": 1,
+      "seed": 1,
+      "z": 0.18762490234400001,
+      "q": 2,
+      "steps": 300,
+      "expected_newsud": ["eusuuuwswdddnennwuuessseednnwwwdde"]
+    },
+    {
+      "name": "figure8_q1_seed2",
+      "knot_type": "4_1",
+      "source_file": "initial/4_1",
+      "component_count": 1,
+      "seed": 2,
+      "z": 0.18762490234400001,
+      "q": 1,
+      "steps": 300,
+      "expected_newsud": ["seuusuuuwwddednnuusssdeenunwdwwdddwnee"]
+    },
+    {
+      "name": "figure8_q2_seed2",
+      "knot_type": "4_1",
+      "source_file": "initial/4_1",
+      "component_count": 1,
+      "seed": 2,
+      "z": 0.18762490234400001,
+      "q": 2,
+      "steps": 300,
+      "expected_newsud": ["euuuuwwdddennuusssedennwwwddse"]
+    },
+    {
+      "name": "unknot_q1_seed1",
+      "knot_type": "0_1",
+      "source_file": "initial/0_1",
+      "component_count": 1,
+      "seed": 1,
+      "z": 0.21343806027490822,
+      "q": 1,
+      "steps": 300,
+      "expected_newsud": ["seeeneeeeeseneeeeeueedseeneeeeeedeeueesenuesdedeneeueeeeeeuedeeeedeeenwwwwwuwnwswwwuwwdwwuswnwwndswuwwswnwdwwwwwdnwwuswwuwwwdwwwwwwwwwdwuwwwsw"]
+    },
+    {
+      "name": "link_2_2_1_q1_seed1",
+      "knot_type": "2_2_1",
+      "source_file": "initial/2_2_1a",
+      "component_count": 2,
+      "seed": 1,
+      "z": 0.20815,
+      "q": 1,
+      "steps": 300,
+      "expected_newsud": ["dwdneseesuunwnws", "dnenenuwwueswsds"]
+    }
+  ]
+}

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(regressionTest
         bfacf_critical_z_test.cpp
         bfacf_regression_test.cpp
         bfacf_step_test.cpp
+        bfacf_stepq_test.cpp
         bfacf_topology_invariance_test.cpp)
 target_link_libraries(regressionTest recombo_core gtest gtest_main)
 target_compile_definitions(regressionTest PRIVATE

--- a/test/regression/bfacf_stepq_test.cpp
+++ b/test/regression/bfacf_stepq_test.cpp
@@ -1,0 +1,127 @@
+// Data-driven regression tests for stepQ()/init_Q() -- a structurally
+// different code path from step() (used by bfacf_critical_z_test.cpp and
+// bfacf_topology_invariance_test.cpp), which has its own q-dependent
+// precomputed probability table (probMap) rather than step()'s direct
+// perform_move(). None of the other regression suites in this project
+// exercise it. These runs are deliberately shorter than the critical-z/
+// topology suites -- the goal here is code-path coverage across several q
+// values and knot/link types, not equilibrium or critical behavior.
+//
+// Cases and expected_newsud values are generated, not hand-typed -- see
+// test/data/bfacf_stepq_cases.json. z-values reused from
+// bfacf_critical_z_test.cpp (same provenance: recovered historical
+// z-value table for 3_1/4_1, CRITICAL_Z for 0_1, DEFAULT_Z for 2_2_1).
+//
+// Observation: figure8_q1_seed1 and figure8_q2_seed1 produced IDENTICAL
+// output despite q=1 and q=2 using different probabilities (verified
+// directly via probMap: e.g. at length 34, p_plus2 is 0.0318 at q=1 vs
+// 0.0335 at q=2 -- genuinely different, not a bug). The two probability
+// sets are close enough that this particular 300-step, seed-1 sequence
+// happened not to cross a differing accept/reject decision. Left in as a
+// real, verified regression case rather than re-seeded to hide it -- it's
+// a noteworthy result in its own right (q can fail to visibly matter for a
+// given short trajectory even though the underlying probabilities differ).
+//
+// To confirm this is a coincidence specific to that seed rather than a
+// sign q is silently ignored, the same comparison was tried for seeds
+// 1..100: seed=1 matched (as above); seed=2 diverged immediately (q=1 ->
+// length 38, q=2 -> length 30, no relation between the two strings at
+// all). Both seed=1 and seed=2 are kept as separate cases below
+// (figure8_q1/q2_seed1, figure8_q1/q2_seed2) so the suite documents both
+// outcomes rather than just the more "expected" one.
+
+#include <gtest/gtest.h>
+#include "test_data_util.h"
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "clkConformationAsList.h"
+#include "clkConformationBfacf3.h"
+
+using namespace std;
+
+struct BfacfStepQCase {
+    string name;
+    string knot_type;
+    string source_file;
+    int component_count;
+    int seed;
+    double z;
+    int q;
+    int steps;
+    vector<string> expected_newsud;
+};
+
+static vector<BfacfStepQCase> loadBfacfStepQCases()
+{
+    json11::Json data = load_test_data("bfacf_stepq_cases.json");
+    vector<BfacfStepQCase> cases;
+
+    for (const json11::Json& item : data["cases"].array_items())
+    {
+        BfacfStepQCase c;
+        c.name = item["name"].string_value();
+        c.knot_type = item["knot_type"].string_value();
+        c.source_file = item["source_file"].string_value();
+        c.component_count = item["component_count"].int_value();
+        c.seed = item["seed"].int_value();
+        c.z = item["z"].number_value();
+        c.q = item["q"].int_value();
+        c.steps = item["steps"].int_value();
+        for (const json11::Json& s : item["expected_newsud"].array_items())
+            c.expected_newsud.push_back(s.string_value());
+        cases.push_back(c);
+    }
+    return cases;
+}
+
+class BfacfStepQTest : public ::testing::TestWithParam<BfacfStepQCase>
+{
+};
+
+TEST_P(BfacfStepQTest, MatchesRecordedResult)
+{
+    const BfacfStepQCase& c = GetParam();
+
+    string fullPath = string(REPO_ROOT_DIR) + "/" + c.source_file;
+    ifstream file(fullPath.c_str());
+    ASSERT_TRUE(file.is_open()) << "Could not open " << fullPath;
+
+    clkConformationAsList comp0, comp1;
+    ASSERT_TRUE(comp0.readFromCoords(file)) << "Could not read component 0 from " << c.source_file;
+
+    unique_ptr<clkConformationBfacf3> knot;
+    if (c.component_count == 2)
+    {
+        ASSERT_TRUE(comp1.readFromCoords(file)) << "Could not read component 1 from " << c.source_file;
+        knot.reset(new clkConformationBfacf3(comp0, comp1));
+    }
+    else
+    {
+        knot.reset(new clkConformationBfacf3(comp0));
+    }
+
+    knot->setSeed(c.seed);
+    knot->init_Q(c.z, c.q);
+    for (int i = 0; i < c.steps; i++)
+        knot->stepQ(c.q, c.z);
+
+    ASSERT_EQ((int)c.expected_newsud.size(), c.component_count) << c.name;
+    for (int i = 0; i < c.component_count; i++)
+    {
+        clkConformationAsList result(knot->getComponent(i));
+        EXPECT_EQ(result.writeAsNewsud(), c.expected_newsud[i])
+            << c.name << ": component " << i << " mismatch";
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RecordedCases,
+    BfacfStepQTest,
+    ::testing::ValuesIn(loadBfacfStepQCases()),
+    [](const ::testing::TestParamInfo<BfacfStepQCase>& info) {
+        return info.param.name;
+    });


### PR DESCRIPTION
Follow-up to #71. That PR added regression coverage for `step()` (critical-z suite, topology-invariance suite) but never touched `stepQ()`/`init_Q()` — a structurally different code path (its own precomputed `probMap` table, not `step()`'s direct `perform_move()`). This PR closes that gap.

## What's included

**New: data-driven stepQ regression suite** (`test/regression/bfacf_stepq_test.cpp` + `test/data/bfacf_stepq_cases.json`)

- 9 cases, same diversity convention as #71 (majority trefoil): 3 trefoil (q=1/2/3, same seed and z, isolating q's effect), 4 figure-eight (q=1/2, two different seeds — see note below), 1 unknot, 1 two-component link (`2_2_1a`).
- Same `TEST_P` + JSON pattern as the rest of the regression suite — one test body, cases are a data change not a code change.
- z-values reused from the critical-z suite for consistency (recovered historical table for 3_1/4_1, `CRITICAL_Z` for `0_1`, `DEFAULT_Z` for `2_2_1`).
- **Deliberately short runs — 300 steps, vs. 1000–20000 in the `step()` suites from #71.** The goal here is code-path coverage across several `q` values and knot/link types, not equilibrium or critical behavior, so there was no reason to pay for longer runs. This also directly reduces exposure to the FP-rounding brittleness flagged in review on #71 (move acceptance compares an exact RNG draw against a floating-point probability that depends on `pow()`/division, which can differ at the ULP level across compilers/optimization levels — fewer steps means fewer chances for a boundary-adjacent comparison to flip and cascade into a fully divergent trajectory). Shorter runs were sufficient for what these tests are actually checking.

## A finding worth flagging explicitly

`figure8_q1_seed1` and `figure8_q2_seed1` produce **identical** output after 300 steps, despite q=1 and q=2 using genuinely different probabilities — verified directly via `probMap` (e.g. at length 34: `p_plus2 = 0.0318` at q=1 vs `0.0335` at q=2). The two probability sets are close enough that this particular short, seed-1 trajectory never crossed a differing accept/reject decision.

Rather than treat that as noise and re-seed it away, we checked whether it was a fluke or a sign `q` was being silently ignored: tried seeds 1..100 for the same comparison, stopping at the first divergence. Seed 2 diverged immediately (q=1 → length 38, q=2 → length 30, unrelated trajectories). Both seed=1 (identical) and seed=2 (divergent) are kept as separate cases in the suite, so it documents both outcomes rather than just the more "expected" one. Full reasoning and the exact `probMap` values are in the test file's header comment.

## Test plan

- Fresh `cmake -B build && cmake --build build`, `ctest` — 156/156 passing.
- New cases verified individually via `--gtest_filter="*BfacfStepQTest*"` — all 9 pass with informative per-case names.
